### PR TITLE
[feat] 플레이어 체력에 따른 초상화 변경 및 Axe 클래스 HP UI 출력 수정

### DIFF
--- a/Assets/JDW/Assets/Scenes/BattleScene.unity
+++ b/Assets/JDW/Assets/Scenes/BattleScene.unity
@@ -337,6 +337,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2528856368926004839, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: playerDataManager
+      value: 
+      objectReference: {fileID: 489905112}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -614,6 +618,50 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+--- !u!1 &489905108 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4279960742447084805, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+  m_PrefabInstance: {fileID: 8615201728655479911}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &489905112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 489905108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49f9733576881494c8358ca2407296f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_isDontDestroyOnLoad: 1
+  GamePlayType: 0
+  TestCharacterClass: 0
+  stats:
+    _hp: 0
+    _baseMaxHp: 0
+    _baseAtk: 0
+    _baseDfs: 0
+    _baseSpd: 0
+    _baseAtkSpd: 0
+    Level: 1
+    CharacterClass: 0
+    CurrentExp: 0
+    MaxExp: 100
+    BaseAtk: 0
+    BaseDfs: 0
+    BaseMaxHp: 0
+    BaseAtkSpd: 0
+    BaseSpd: 0
+  inventoryItems: []
+  currentStageFloor: 0
+  monstersDefeated: 0
+  gold: 0
+  diamonds: 0
+  CurrentAffinityExp: 0
+  CurrentAffinityLevel: 0
+  WornCostumeName: 
 --- !u!1001 &578895056
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -969,6 +1017,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1673134169377035974, guid: 9a01c57ead4472c4f9a55904a36f7e39, type: 3}
       propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576493993212972030, guid: 9a01c57ead4472c4f9a55904a36f7e39, type: 3}
+      propertyPath: m_IsTrigger
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7587761201080512381, guid: 9a01c57ead4472c4f9a55904a36f7e39, type: 3}
@@ -1889,7 +1941,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1891085507804937879, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[0].second.m_AnimationSpeed
-      value: 5
+      value: 5.0000005
       objectReference: {fileID: 0}
     - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1969,7 +2021,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[7].second.m_AnimationSpeed
-      value: 5.0000005
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[8].second.m_AnimationSpeed
@@ -2238,7 +2290,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4279960742447084805, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 489905112}
   m_SourcePrefab: {fileID: 100100000, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
 --- !u!1001 &9029448214279045747
 PrefabInstance:

--- a/Assets/JDW/Assets/Scenes/BattleScene.unity
+++ b/Assets/JDW/Assets/Scenes/BattleScene.unity
@@ -122,27 +122,555 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &169719047
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6042697840603409780, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: _exp
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.5531373
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.2812476
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+--- !u!1001 &204038403
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.77
+      objectReference: {fileID: 0}
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.33290842
+      objectReference: {fileID: 0}
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5423907406913552007, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+      propertyPath: m_Name
+      value: PlayerSpawner
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
 --- !u!1 &212648505 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 3461810146224205066, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-  m_PrefabInstance: {fileID: 2696657322588739653}
+  m_CorrespondingSourceObject: {fileID: 1120198408573429420, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+  m_PrefabInstance: {fileID: 5774529962527405935}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &265971149
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 594729052}
+    m_Modifications:
+    - target: {fileID: 887665393235959255, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_Name
+      value: FieldUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1920
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1080
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 225
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
 --- !u!4 &309726189 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5790655664166051410, guid: 284a655a1fc11b144b6449e992b88018, type: 3}
   m_PrefabInstance: {fileID: 204870100374672801}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &579281399 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2933088364726498677, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-  m_PrefabInstance: {fileID: 7126162326302553815}
+--- !u!1001 &342618306
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.101298
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4698973996789699583, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: m_Name
+      value: TestDamageItem 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6747043472239545706, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+      propertyPath: price
+      value: 50
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5e538a8e538d4fc4e9c7e29db738ec8f, type: 3}
+--- !u!1 &347073300 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5875567109277795886, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+  m_PrefabInstance: {fileID: 5774529962527405935}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+--- !u!4 &347073301 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+  m_PrefabInstance: {fileID: 5774529962527405935}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &347073302
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 347073300}
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fd7ca34113a6b9345be7769e98a29b36, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 9f451b7f4060e4b4f9e314cfa29256f9, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!1001 &348024693
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6042697840603409780, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: _exp
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 6.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+--- !u!1001 &419432318
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.1299033
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.7873535
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+--- !u!1001 &486685651
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.1805687
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.8381467
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+--- !u!1001 &578895056
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
 --- !u!1 &594729048
 GameObject:
   m_ObjectHideFlags: 0
@@ -237,8 +765,8 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5889143089640962421}
-  - {fileID: 8627575080605300014}
+  - {fileID: 1876310346}
+  - {fileID: 1395731608}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -246,27 +774,186 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1 &944977997 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1952401816865250898, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-  m_PrefabInstance: {fileID: 3831829889928145331}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &944978001
-MonoBehaviour:
+--- !u!1001 &868768327
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 944977997}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 51a57ce8b65b8124f84d64450802531d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.09193
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.433259
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
 --- !u!1 &962576083 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 5014391466852697424, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-  m_PrefabInstance: {fileID: 2696657322588739653}
+  m_CorrespondingSourceObject: {fileID: 7442590869078721265, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+  m_PrefabInstance: {fileID: 5774529962527405935}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1231496543
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.3126006
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.95230675
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+--- !u!1001 &1346756858
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.502346
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.142052
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+--- !u!224 &1395731608 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+  m_PrefabInstance: {fileID: 2927483902300458950}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1421284865
 PrefabInstance:
@@ -282,14 +969,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1673134169377035974, guid: 9a01c57ead4472c4f9a55904a36f7e39, type: 3}
       propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5619523104021871816, guid: 9a01c57ead4472c4f9a55904a36f7e39, type: 3}
-      propertyPath: _bossHpBar
-      value: 
-      objectReference: {fileID: 3719136568851208046}
-    - target: {fileID: 7576493993212972030, guid: 9a01c57ead4472c4f9a55904a36f7e39, type: 3}
-      propertyPath: m_IsTrigger
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7587761201080512381, guid: 9a01c57ead4472c4f9a55904a36f7e39, type: 3}
@@ -337,11 +1016,243 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9a01c57ead4472c4f9a55904a36f7e39, type: 3}
+--- !u!1001 &1528193059
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.74
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.101298
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4698973996789699583, guid: 987692278a08def4a8604f987298aed9, type: 3}
+      propertyPath: m_Name
+      value: TestDefenseItem 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 987692278a08def4a8604f987298aed9, type: 3}
+--- !u!1001 &1576296623
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.101298
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650443005028075410, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4698973996789699583, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: m_Name
+      value: TestBasicItem 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6747043472239545706, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+      propertyPath: price
+      value: 20
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 356649a92c32e9340ae81470059b1730, type: 3}
+--- !u!1001 &1700072442
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.712078
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.546938
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
 --- !u!1 &1737556449 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 5866157199781102410, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-  m_PrefabInstance: {fileID: 2696657322588739653}
+  m_CorrespondingSourceObject: {fileID: 2024109990779497852, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+  m_PrefabInstance: {fileID: 5774529962527405935}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1739015281
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.509515
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.2179976
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
 --- !u!1001 &1806502962
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -403,11 +1314,73 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 12dd3a1cda959224b9f678d86197a0a7, type: 3}
+--- !u!224 &1876310346 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
+  m_PrefabInstance: {fileID: 265971149}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1951308270 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 7383976153234047968, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-  m_PrefabInstance: {fileID: 2696657322588739653}
+  m_CorrespondingSourceObject: {fileID: 4441589675626498129, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+  m_PrefabInstance: {fileID: 5774529962527405935}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1965086350
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.4212255
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.4331403
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
 --- !u!1 &1981038605
 GameObject:
   m_ObjectHideFlags: 0
@@ -570,11 +1543,63 @@ MonoBehaviour:
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
   m_ScrollDeltaPerTick: 6
---- !u!1 &119755783296741697 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2805042289713139985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-  m_PrefabInstance: {fileID: 2696657322588739653}
-  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2048932545
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1537394790108370385, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_Name
+      value: Monster (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.6798754
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.407744
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8939059610055477475, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dd9bd665ddfedeb4f8a81202b6495a24, type: 3}
 --- !u!1001 &204870100374672801
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -677,13 +1702,120 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 5790655664166051410, guid: 284a655a1fc11b144b6449e992b88018, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 8696945770031288227}
+      addedObject: {fileID: 347073301}
     - targetCorrespondingSourceObject: {fileID: 5790655664166051410, guid: 284a655a1fc11b144b6449e992b88018, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 5498128790441304756}
+      addedObject: {fileID: 230165844688370082}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 284a655a1fc11b144b6449e992b88018, type: 3}
---- !u!1001 &2696657322588739653
+--- !u!4 &230165844688370082 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+  m_PrefabInstance: {fileID: 9029448214279045747}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2810052627920086071 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6334962763312544992, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+  m_PrefabInstance: {fileID: 9029448214279045747}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2927483902300458950
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 594729052}
+    m_Modifications:
+    - target: {fileID: 5474093859943094938, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_Name
+      value: Fade
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726554861945353907, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
+--- !u!1001 &5774529962527405935
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -691,606 +1823,327 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 309726189}
     m_Modifications:
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalRotation.w
+    - target: {fileID: 92922802454981829, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_ColliderPaths.Array.size
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2805042289713139985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_Name
-      value: BattleFeld
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[3].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[4].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[5].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[6].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[8].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[9].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[10].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[11].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[12].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[13].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[14].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[15].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[16].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[17].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[18].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[19].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[23].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[24].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[25].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[26].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[27].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[28].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[29].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3875305477331122985, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[30].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3976199786099585896, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[1].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3976199786099585896, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[2].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3976199786099585896, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[4].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3976199786099585896, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[5].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3976199786099585896, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[6].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3976199786099585896, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[8].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3976199786099585896, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[9].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3976199786099585896, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[10].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3976199786099585896, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-      propertyPath: m_AnimatedTiles.Array.data[13].second.m_AnimationSpeed
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7888725892727909482, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[0].second.m_AnimationSpeed
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 7888725892727909482, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[1].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[2].second.m_AnimationSpeed
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 7888725892727909482, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[3].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[4].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[5].second.m_AnimationSpeed
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 7888725892727909482, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[6].second.m_AnimationSpeed
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 7888725892727909482, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[7].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[8].second.m_AnimationSpeed
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 7888725892727909482, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[9].second.m_AnimationSpeed
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 7888725892727909482, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[10].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[11].second.m_AnimationSpeed
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 7888725892727909482, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[12].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 625758299131771086, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_AnimatedTiles.Array.data[13].second.m_AnimationSpeed
       value: 5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
---- !u!1 &3072937491896041107 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2520660307020247030, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-  m_PrefabInstance: {fileID: 5500230912495218452}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &3719136568851208046 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3012218953203262792, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-  m_PrefabInstance: {fileID: 7126162326302553815}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3831829889928145331
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1952401816865250898, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-      propertyPath: m_Name
-      value: GameManager
+    - target: {fileID: 1846303971110260353, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_ColliderPaths.Array.size
+      value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3725951337570423594, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-      propertyPath: timer
-      value: 
-      objectReference: {fileID: 579281399}
-    - target: {fileID: 3725951337570423594, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-      propertyPath: Tilemap
-      value: 
-      objectReference: {fileID: 119755783296741697}
-    - target: {fileID: 5195289558020823262, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-      propertyPath: Tilemap1
-      value: 
-      objectReference: {fileID: 1951308270}
-    - target: {fileID: 5195289558020823262, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-      propertyPath: Tilemap2
-      value: 
-      objectReference: {fileID: 962576083}
-    - target: {fileID: 5195289558020823262, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-      propertyPath: Tilemap3
-      value: 
-      objectReference: {fileID: 1737556449}
-    - target: {fileID: 5195289558020823262, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-      propertyPath: Tilemap4
-      value: 
-      objectReference: {fileID: 212648505}
-    - target: {fileID: 5195289558020823262, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-      propertyPath: storeField
-      value: 
-      objectReference: {fileID: 3072937491896041107}
-    - target: {fileID: 5195289558020823262, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
-      propertyPath: battleField
-      value: 
-      objectReference: {fileID: 119755783296741697}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 1891085507804937879, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[0].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.3876872
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.62525725
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.015821384
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8052504543623916493, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - target: {fileID: 2923542588156197068, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4314162325842657936, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_ColliderPaths.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4800115803559306762, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_ColliderPaths.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5445687068672758088, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_ColliderPaths.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[0].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[1].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[2].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[3].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[4].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[5].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[7].second.m_AnimationSpeed
+      value: 5.0000005
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[8].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[9].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[10].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[11].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[12].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[13].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5739192214936398795, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[14].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875567109277795886, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_Name
+      value: GameObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 5875567109277795886, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6942240327894822823, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_ColliderPaths.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[0].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[1].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[2].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[3].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[4].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[5].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[6].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[7].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[8].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[9].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[10].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[11].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[12].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[13].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[14].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[15].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[16].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[17].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[18].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[19].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[20].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[21].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[22].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[23].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[24].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[25].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[26].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[27].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[28].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[29].second.m_AnimationSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7934582488209846424, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+      propertyPath: m_AnimatedTiles.Array.data[30].second.m_AnimationSpeed
+      value: 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 1952401816865250898, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
+    - targetCorrespondingSourceObject: {fileID: 5875567109277795886, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 944978001}
-  m_SourcePrefab: {fileID: 100100000, guid: 75d1e26677b4bff4e90dd67a4fdb5785, type: 3}
---- !u!114 &4543172785762470377 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3430800731980778163, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-  m_PrefabInstance: {fileID: 6478393460648359698}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7df408009439ecb4ba02010ada089a88, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &5498128790441304756 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-  m_PrefabInstance: {fileID: 5500230912495218452}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &5500230912495218452
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 309726189}
-    m_Modifications:
-    - target: {fileID: 2520660307020247030, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_Name
-      value: ShopField
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -16.98
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -5.33
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6779498008433248157, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c6c9c972092740c4d829589abbcffaf0, type: 3}
---- !u!224 &5889143089640962421 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-  m_PrefabInstance: {fileID: 6478393460648359698}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &6478393460648359698
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 594729052}
-    m_Modifications:
-    - target: {fileID: 5381904479531682428, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_Name
-      value: Fade
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7716056568890411718, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b745fd77118e9a34fa4a78663ad6b8ed, type: 3}
---- !u!1001 &7126162326302553815
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 594729052}
-    m_Modifications:
-    - target: {fileID: 887665393235959255, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_Name
-      value: FieldUI
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 1920
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 1080
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 400
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 225
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2933088364726498677, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: totalTime
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2933088364726498677, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: mapSwitcer
-      value: 
-      objectReference: {fileID: 944978001}
-    - target: {fileID: 2933088364726498677, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-      propertyPath: fadeManager
-      value: 
-      objectReference: {fileID: 4543172785762470377}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
---- !u!1001 &8577607322040487918
+      addedObject: {fileID: 347073302}
+  m_SourcePrefab: {fileID: 100100000, guid: 60f400a14c0971140b0e6e0c5bfc87af, type: 3}
+--- !u!1001 &8615201728655479911
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -1298,78 +2151,180 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 4279960742447084805, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: m_Name
+      value: GameManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 7238456504662222757, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: Tilemap1
+      value: 
+      objectReference: {fileID: 1951308270}
+    - target: {fileID: 7238456504662222757, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: Tilemap2
+      value: 
+      objectReference: {fileID: 962576083}
+    - target: {fileID: 7238456504662222757, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: Tilemap3
+      value: 
+      objectReference: {fileID: 1737556449}
+    - target: {fileID: 7238456504662222757, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: Tilemap4
+      value: 
+      objectReference: {fileID: 212648505}
+    - target: {fileID: 7238456504662222757, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: storeField
+      value: 
+      objectReference: {fileID: 2810052627920086071}
+    - target: {fileID: 7238456504662222757, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: battleField
+      value: 
+      objectReference: {fileID: 347073300}
+    - target: {fileID: 7866467489833683709, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: Boss
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7866467489833683709, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: Store
+      value: 
+      objectReference: {fileID: 2810052627920086071}
+    - target: {fileID: 7866467489833683709, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: timer
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7866467489833683709, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+      propertyPath: Tilemap
+      value: 
+      objectReference: {fileID: 347073300}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.97
+      value: -1.3876872
       objectReference: {fileID: 0}
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -3.7
+      value: 0.62525725
       objectReference: {fileID: 0}
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.33290842
+      value: -0.015821384
       objectReference: {fileID: 0}
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1315861537661493377, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
+    - target: {fileID: 8605384738218336565, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5423907406913552007, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
-      propertyPath: m_Name
-      value: PlayerSpawner
-      objectReference: {fileID: 0}
-    - target: {fileID: 5423907406913552007, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
-      propertyPath: m_TagString
-      value: PlayerSpawn
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e1acffaad0f9aa54da553b9415f07f21, type: 3}
---- !u!224 &8627575080605300014 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1199622639844006114, guid: 5cd9412504e71e84b8708fae56cfc1db, type: 3}
-  m_PrefabInstance: {fileID: 7126162326302553815}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &8696945770031288227 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 899079213366019005, guid: 792b99f22b2f9ac479ba1ca1594534de, type: 3}
-  m_PrefabInstance: {fileID: 2696657322588739653}
-  m_PrefabAsset: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 08a1e40f6f045dd49ac3fece0a502b13, type: 3}
+--- !u!1001 &9029448214279045747
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 309726189}
+    m_Modifications:
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -16.98
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531468958831567047, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6334962763312544992, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_Name
+      value: ShopField
+      objectReference: {fileID: 0}
+    - target: {fileID: 6334962763312544992, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0b106adf611f274479a32f663ce94a87, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 3831829889928145331}
+  - {fileID: 8615201728655479911}
   - {fileID: 204870100374672801}
   - {fileID: 594729052}
   - {fileID: 2018397893}
   - {fileID: 1981038608}
   - {fileID: 1806502962}
+  - {fileID: 1576296623}
+  - {fileID: 1528193059}
+  - {fileID: 342618306}
   - {fileID: 1421284865}
-  - {fileID: 8577607322040487918}
+  - {fileID: 578895056}
+  - {fileID: 1965086350}
+  - {fileID: 169719047}
+  - {fileID: 2048932545}
+  - {fileID: 486685651}
+  - {fileID: 1346756858}
+  - {fileID: 1231496543}
+  - {fileID: 348024693}
+  - {fileID: 1700072442}
+  - {fileID: 419432318}
+  - {fileID: 1739015281}
+  - {fileID: 868768327}
+  - {fileID: 204038403}

--- a/Assets/JDW/Assets/Scenes/Map/Script/FadeManager.cs
+++ b/Assets/JDW/Assets/Scenes/Map/Script/FadeManager.cs
@@ -5,22 +5,23 @@ using UnityEngine;
 
 public class FadeManager : MonoBehaviour
 {
-    public GameObject fadeImage;
+    public GameObject FadeImage;
     // 페이드 인 / 아웃 시간
-    public float fadeDuration = 1f;
+    public float FadeDuration = 1f;
     // 화면을 검은 원으로 덮는 효과
     public IEnumerator FadeOut()
     {
-        fadeImage.SetActive(true);
-        Transform circle = fadeImage.transform; 
+        FadeImage.SetActive(true);
+        Transform circle = FadeImage.transform; 
         circle.localScale = Vector3.zero;
 
         float time = 0f;
-        while(time < fadeDuration)
+
+        while(time < FadeDuration)
         {
             time += Time.deltaTime;
             // 시간에 따라 스케일 값을 키움
-            float scale = Mathf.Lerp(0f, 50f, time / fadeDuration);
+            float scale = Mathf.Lerp(0f, 50f, time / FadeDuration);
             circle.localScale = new Vector3(scale, scale, 1f);
             yield return null;
         }
@@ -28,18 +29,18 @@ public class FadeManager : MonoBehaviour
     // 화면에 원이 작아지는 효과
     public IEnumerator FadeIn()
     {
-        Transform circle = fadeImage.transform;
+        Transform circle = FadeImage.transform;
         circle.localScale = new Vector3(3f, 3f, 1f);
 
         float time = 0f;
-        while (time < fadeDuration)
+        while (time < FadeDuration)
         {
             time += Time.deltaTime;
             // 시간에 따라 스케일 값을 줄임
-            float scale = Mathf.Lerp(50f, 0f, time / fadeDuration);
+            float scale = Mathf.Lerp(50f, 0f, time / FadeDuration);
             circle.localScale = new Vector3(scale, scale, 1f);
             yield return null;
         }
-        fadeImage.SetActive(false);
+        FadeImage.SetActive(false);
     }
 }

--- a/Assets/JDW/Assets/Scenes/Map/Script/GameManager.cs
+++ b/Assets/JDW/Assets/Scenes/Map/Script/GameManager.cs
@@ -9,11 +9,6 @@ public class GameManager : SimpleSingleton<GameManager>
 {
     [HideInInspector] public PlayerConfig Player;
     public int CurrentClassIndex { get; private set; }
-    private GameObject currentPlayerInstance;
-    public PlayerStats SavedStats;
-    public void SavePlayerStats(PlayerStats stats)
-    {
-        SavedStats = stats.Clone(); // 플레이어 데이터 복사
-    }
+    private GameObject _currentPlayerInstance;
 }
 

--- a/Assets/JDW/Assets/Scenes/Map/Script/Reposition.cs
+++ b/Assets/JDW/Assets/Scenes/Map/Script/Reposition.cs
@@ -4,13 +4,14 @@ using UnityEngine;
 
 public class Reposition : MonoBehaviour
 {
-    public bool isActive = true;
+    public bool IsActive = true;
+
     private PlayerMove _playerMove;
     private PlayerConfig _player;
 
     private void OnTriggerExit2D(Collider2D collision)
     {
-        if (!isActive) return;
+        if (!IsActive) return;
         // 벗어난 콜라이더가 "Area" 태그를 가지고 있지 않으면 아무 작업도 하지 않고 종료
         if (!collision.CompareTag("Area"))
             return;
@@ -27,34 +28,34 @@ public class Reposition : MonoBehaviour
             return;
         }
         // 플레이어의 현재 위치를 가져옴
-        Vector3 _playerPos = _player.transform.position;
+        Vector3 playerPos = _player.transform.position;
         // 현재 오브젝트의 위치
-        Vector3 _myPos = transform.position;
+        Vector3 myPos = transform.position;
         // 플레이어 위치와 오브젝트 위치의 x, y 거리 차이 계산
-        float _diffx = Mathf.Abs(_playerPos.x - _myPos.x);
-        float _diffy = Mathf.Abs(_playerPos.y - _myPos.y);
+        float diffx = Mathf.Abs(playerPos.x - myPos.x);
+        float diffy = Mathf.Abs(playerPos.y - myPos.y);
         // 플레이어가 입력한 방향 벡터
-        Vector3 _playerDir = GetPlayerMoveInput();
+        Vector3 playerDir = GetPlayerMoveInput();
         // x축 방향 : 왼쪽이면 -1, 아니면 +1
-        float _dirx = _playerDir.x < 0 ? -1 : 1;
+        float dirx = playerDir.x < 0 ? -1 : 1;
         // y축 방향 : 아래쪽이면 -1 , 아니면 +1
-        float _diry = _playerDir.y < 0 ? -1 : 1;
+        float diry = playerDir.y < 0 ? -1 : 1;
 
         //현재 오브젝트의 태그에 따라 처리 분기
         switch (transform.tag)
         {
             case "Ground":
                 // x축 차이가 더 크면 좌우로 이동
-                if (_diffx > _diffy)
+                if (diffx > diffy)
                 {
                     // x축 방향으로 40만큼 이동
-                    transform.Translate(Vector3.right * _dirx * 80);
+                    transform.Translate(Vector3.right * dirx * 80);
                 }
                 // y축 차이가 더 크면 상하로 이동
-                else if (_diffx < _diffy)
+                else if (diffx < diffy)
                 {
                     // y축 방향으로 40만큼 이동
-                    transform.Translate(Vector3.up * _diry * 80);
+                    transform.Translate(Vector3.up * diry * 80);
                 }
                 break;
             case "Enemy":

--- a/Assets/JDW/Assets/Scenes/Map/Script/Timer.cs
+++ b/Assets/JDW/Assets/Scenes/Map/Script/Timer.cs
@@ -6,36 +6,37 @@ using UnityEngine.UI;
 
 public class Timer : MonoBehaviour
 {
-    public float totalTime = 900f; //15분
-    public float currentTime;
-    public TextMeshProUGUI timerText; // TMP 사용
-    public FadeManager fadeManager;
+    public float TotalTime = 900f; //15분
+    public float CurrentTime;
+
+    public TextMeshProUGUI TimerText; // TMP 사용
+    public FadeManager FadeManager;
+    public MapSwitcher MapSwitcer;
+
     private bool _paused = false;
 
-    public MapSwitcher mapSwitcer;
     private void Start()
     {
-        currentTime = totalTime;
+        CurrentTime = TotalTime;
     }
     private void Update()
     {
         if (_paused) return;
 
-        if (currentTime > 0f)
+        if (CurrentTime > 0f)
         {
             // 현재 남은 시간에서 실시간 감소
-            currentTime -= Time.deltaTime;
+            CurrentTime -= Time.deltaTime;
 
 
-            int minutes = Mathf.FloorToInt(currentTime / 60f);
-            int seconds = Mathf.FloorToInt(currentTime % 60f);
+            int minutes = Mathf.FloorToInt(CurrentTime / 60f);
+            int seconds = Mathf.FloorToInt(CurrentTime % 60f);
 
-            timerText.text = string.Format("{0:00}:{1:00}", minutes, seconds);
+            TimerText.text = string.Format("{0:00}:{1:00}", minutes, seconds);
         }
         else
         {
-            timerText.text = "00:00"; // 시간 종료시
-            // 시간 종료시 코루틴을 호출해 페이드 효과
+            TimerText.text = "00:00";
             StartCoroutine(HandleFadeTransition());
             // TODO : 신 매니저 추가해서 신이동 코드 추가 요망
         }
@@ -53,15 +54,16 @@ public class Timer : MonoBehaviour
     private IEnumerator HandleFadeTransition()
     {
 
-        yield return StartCoroutine(fadeManager.FadeOut()); // 패이드 아웃
-        // 상점 온/ 배틀 오프
-        yield return StartCoroutine(fadeManager.FadeIn());
-        currentTime = totalTime; // 타이머 초기화
+        yield return StartCoroutine(FadeManager.FadeOut());
+        yield return StartCoroutine(FadeManager.FadeIn());
+        CurrentTime = TotalTime; // 타이머 초기화
 
     }
     public void SetMessage(string msg)
     {
-        if (timerText != null)
-            timerText.text = msg;
+        if (TimerText != null)
+        {
+            TimerText.text = msg;
+        }
     }
 }

--- a/Assets/JDW/Assets/Scenes/Player/CursorPointer.prefab
+++ b/Assets/JDW/Assets/Scenes/Player/CursorPointer.prefab
@@ -1,0 +1,146 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5642488517265261260
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3504526921716497162}
+  - component: {fileID: 6768469714234102091}
+  m_Layer: 0
+  m_Name: Triangle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3504526921716497162
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5642488517265261260}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.7576582}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1844442455343672324}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6768469714234102091
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5642488517265261260}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 75f5f34dc1b5347e0b8351032682f224, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &5874513840534949430
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1844442455343672324}
+  - component: {fileID: 3214177102962600456}
+  - component: {fileID: 8994524319637365489}
+  m_Layer: 0
+  m_Name: CursorPointer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1844442455343672324
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5874513840534949430}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.1625192, y: -0.92682385, z: -0.7576582}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3504526921716497162}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3214177102962600456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5874513840534949430}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e430981b2b847c48a97f14573053239, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8994524319637365489
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5874513840534949430}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63af3060ea3e83c4b809c779f5c090c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
+  distance: 2

--- a/Assets/JDW/Assets/Scenes/Player/CursorPointer.prefab.meta
+++ b/Assets/JDW/Assets/Scenes/Player/CursorPointer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 874599626ceb8ca4e9f83e8ffed726fb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JDW/Assets/Scenes/Player/Script/AttackPosition.cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/AttackPosition.cs
@@ -58,46 +58,42 @@ public class AttackPosition : MonoBehaviour
     {
         while (true)
         {
-            if (_playerScript != null && _playerScript.isDead)
+            if (_playerScript != null && _playerScript.isDead) // 플레이 사망 시 멈춤
                 yield break;
 
             if (_axePrefab != null)
             {
-                // 마우스 방향 계산
-                Vector2 mouseScreenPos = Mouse.current.position.ReadValue();
-                Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(new Vector3(mouseScreenPos.x, mouseScreenPos.y, Mathf.Abs(Camera.main.transform.position.z)));
+                // 커서 위치를 월드 좌표로 변환
+                Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());
                 mouseWorldPos.z = 0f;
-                Vector3 direction = (mouseWorldPos - Player.position).normalized;
-
-                
+                // 방향 계산 마우스>플레이어
+                Vector3 direction = (mouseWorldPos - Player.position);
+                if (direction.sqrMagnitude < 0.01f) direction = Vector3.right;
+                direction.Normalize();
+                // 방향에 따라 z 축으로 회전
+                float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
+                // 플레이어와 공격 오브젝트의 거리
                 Vector3 spawnPos = Player.position + direction * 0.5f;
+                // 오브젝트 생성 / 회전 적용
+                GameObject axe = Instantiate(_axePrefab, spawnPos, Quaternion.Euler(0f, 0f, angle));
+                // 공격력 정보를 가져와 적용
+                axe.GetComponent<Attack>()?.SetDamage(_playerScript.Stats.CurrentAtk);
 
-                GameObject axe = Instantiate(_axePrefab, spawnPos, Quaternion.identity);
-                axe.transform.right = direction;
 
-                // 공격력 설정
-                float atk = _playerScript.Stats.CurrentAtk;
-                Attack attackScript = axe.GetComponent<Attack>();
-                if (attackScript != null)
-                {
-                    attackScript.SetDamage(atk);
-                }
-
-                // 지정한 시간동안 플레이어를 따라감
-                float duration = 0.4f;
+                // 일정 시간 동안 플레이어를 따라감
                 float elapsed = 0f;
+                float duration = 0.4f;
                 while (elapsed < duration)
                 {
-                    if (axe == null || Player == null)
-                        break;
+                    if (axe == null || Player == null) break;
 
-                    axe.transform.position = Player.position + direction * 1f; // 플레이어보다 앞쪽으로 지정한 단위 거리 위치에 생성
-                    axe.transform.right = direction;
+                    axe.transform.position = Player.position + direction * 1f;
+                    axe.transform.rotation = Quaternion.Euler(0f, 0f, angle);
 
                     elapsed += Time.deltaTime;
                     yield return null;
                 }
-
+                // 오브젝트 제거
                 Destroy(axe);
             }
 
@@ -110,46 +106,40 @@ public class AttackPosition : MonoBehaviour
         // 무한 반복
         while (true)
         {
-            if (_playerScript != null && _playerScript.isDead)
+            if (_playerScript != null && _playerScript.isDead) // 플레이 사망 시 멈춤
                 yield break;
 
-            if (_swordPrefab != null)
+            if (_axePrefab != null)
             {
-                // 마우스 방향 계산
-                Vector2 mouseScreenPos = Mouse.current.position.ReadValue();
-                Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(new Vector3(mouseScreenPos.x, mouseScreenPos.y, Mathf.Abs(Camera.main.transform.position.z)));
+                // 커서 위치를 월드 좌표로 변환
+                Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());
                 mouseWorldPos.z = 0f;
-                Vector3 direction = (mouseWorldPos - Player.position).normalized;
-
-
+                // 방향 계산 마우스>플레이어
+                Vector3 direction = (mouseWorldPos - Player.position);
+                if (direction.sqrMagnitude < 0.01f) direction = Vector3.right;
+                direction.Normalize();
+                // 방향에 따라 z 축으로 회전
+                float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
+                // 플레이어와 공격 오브젝트의 거리
                 Vector3 spawnPos = Player.position + direction * 0.5f;
+                // 오브젝트 생성 / 회전 적용
+                GameObject sword = Instantiate(_swordPrefab, spawnPos, Quaternion.Euler(0f, 0f, angle));
+                // 공격력 정보를 가져와 적용
+                sword.GetComponent<Attack>()?.SetDamage(_playerScript.Stats.CurrentAtk);
 
-                GameObject sword = Instantiate(_swordPrefab, spawnPos, Quaternion.identity);
-                sword.transform.right = direction;
 
-                // 공격력 설정
-                float atk = _playerScript.Stats.CurrentAtk;
-                Attack attackScript = sword.GetComponent<Attack>();
-                if (attackScript != null)
-                {
-                    attackScript.SetDamage(atk);
-                }
-
-                // 지정한 시간동안 플레이어를 따라감
-                float duration = 0.2f;
+                // 일정 시간 동안 플레이어를 따라감
                 float elapsed = 0f;
+                float duration = 0.2f;
                 while (elapsed < duration)
                 {
-                    if (sword == null || Player == null)
-                        break;
-
-                    sword.transform.position = Player.position + direction * 0.5f; // 플레이어보다 앞쪽으로 지정한 단위 거리 위치에 생성
-                    sword.transform.right = direction;
-
+                    if (sword == null || Player == null) break;
+                    sword.transform.position = Player.position + direction * 1f;
+                    sword.transform.rotation = Quaternion.Euler(0f, 0f, angle);
                     elapsed += Time.deltaTime;
                     yield return null;
                 }
-
+                // 오브젝트 제거
                 Destroy(sword);
             }
 
@@ -162,47 +152,41 @@ public class AttackPosition : MonoBehaviour
         // 무한 반복
         while (true)
         {
-            if (_playerScript != null && _playerScript.isDead)
+            if (_playerScript != null && _playerScript.isDead) // 플레이 사망 시 멈춤
                 yield break;
 
-            if (_bulletPrefab != null)
+            if (_axePrefab != null)
             {
-                // 마우스 방향 계산
-                Vector2 mouseScreenPos = Mouse.current.position.ReadValue();
-                Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(new Vector3(mouseScreenPos.x, mouseScreenPos.y, Mathf.Abs(Camera.main.transform.position.z)));
+                // 커서 위치를 월드 좌표로 변환
+                Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());
                 mouseWorldPos.z = 0f;
-                Vector3 direction = (mouseWorldPos - Player.position).normalized;
-
-
+                // 방향 계산 마우스>플레이어
+                Vector3 direction = (mouseWorldPos - Player.position);
+                if (direction.sqrMagnitude < 0.01f) direction = Vector3.right;
+                direction.Normalize();
+                // 방향에 따라 z 축으로 회전
+                float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
+                // 플레이어와 공격 오브젝트의 거리
                 Vector3 spawnPos = Player.position + direction * 0.5f;
+                // 오브젝트 생성 / 회전 적용
+                GameObject bullet = Instantiate(_bulletPrefab, spawnPos, Quaternion.Euler(0f, 0f, angle));
+                // 공격력 정보를 가져와 적용
+                bullet.GetComponent<Attack>()?.SetDamage(_playerScript.Stats.CurrentAtk);
 
-                GameObject bulle = Instantiate(_bulletPrefab, spawnPos, Quaternion.identity);
-                bulle.transform.right = direction;
 
-                // 공격력 설정
-                float atk = _playerScript.Stats.CurrentAtk;
-                Attack attackScript = bulle.GetComponent<Attack>();
-                if (attackScript != null)
-                {
-                    attackScript.SetDamage(atk);
-                }
-
-                // 지정한 시간동안 플레이어를 따라감
-                float duration = 0.7f;
+                // 일정 시간 동안 플레이어를 따라감
                 float elapsed = 0f;
+                float duration = 0.7f; // 공격 유지시간
                 while (elapsed < duration)
                 {
-                    if (bulle == null || Player == null)
-                        break;
-
-                    bulle.transform.position = Player.position + direction * 0.5f; // 플레이어보다 앞쪽으로 지정한 단위 거리 위치에 생성
-                    bulle.transform.right = direction;
-
+                    if (bullet == null || Player == null) break;
+                    bullet.transform.position = Player.position + direction * 0.5f; // 오브젝트가 생성 될 거리
+                    bullet.transform.rotation = Quaternion.Euler(0f, 0f, angle);
                     elapsed += Time.deltaTime;
                     yield return null;
                 }
-
-                Destroy(bulle);
+                // 오브젝트 제거
+                Destroy(bullet);
             }
 
             // 공격속도가 높아질수록 딜레이가 짧아짐
@@ -219,5 +203,4 @@ public class AttackPosition : MonoBehaviour
         }
         return 1f / atkSpeed;
     }
-
 }

--- a/Assets/JDW/Assets/Scenes/Player/Script/AttackPosition.cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/AttackPosition.cs
@@ -5,6 +5,8 @@ using ProjectVS;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
+using static UnityEditor.Experimental.GraphView.GraphView;
+
 public class AttackPosition : MonoBehaviour
 {
     public Transform Player;
@@ -14,13 +16,13 @@ public class AttackPosition : MonoBehaviour
     [SerializeField] private Transform _muzzlePos;
 
     private Coroutine _currentRoutine;
-    private PlayerConfig _playerScript;
+    private PlayerConfig _player;
 
     private void Awake()
     {
         if (Player != null)
         {
-            _playerScript = Player.GetComponent<PlayerConfig>();
+            _player = Player.GetComponent<PlayerConfig>();
         }
     }
     private void Update()
@@ -29,7 +31,7 @@ public class AttackPosition : MonoBehaviour
     }
     public void SwitchCoroutine(IEnumerator newRoutine)
     {
-        // 코루틴 스위칭 함수
+        // 코루틴 스위치 함수
         if (_currentRoutine != null)
         {
             StopCoroutine(_currentRoutine);
@@ -37,170 +39,78 @@ public class AttackPosition : MonoBehaviour
         _currentRoutine = StartCoroutine(newRoutine);
     }
 
-    private IEnumerator FollowAndDestroy(GameObject obj, Transform target, float duration)
-    {
-        float time = 0f;
-
-        while (time < duration)
-        {
-            if (obj == null || target == null)
-                yield break;
-
-            obj.transform.position = target.position;
-
-            time += Time.deltaTime;
-            yield return null;
-        }
-
-        Destroy(obj);
-    }
     public IEnumerator Axe()
     {
-        while (true)
-        {
-            if (_playerScript != null && _playerScript.isDead) // 플레이 사망 시 멈춤
-                yield break;
-
-            if (_axePrefab != null)
-            {
-                // 커서 위치를 월드 좌표로 변환
-                Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());
-                mouseWorldPos.z = 0f;
-                // 방향 계산 마우스>플레이어
-                Vector3 direction = (mouseWorldPos - Player.position);
-                if (direction.sqrMagnitude < 0.01f) direction = Vector3.right;
-                direction.Normalize();
-                // 방향에 따라 z 축으로 회전
-                float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
-                // 플레이어와 공격 오브젝트의 거리
-                Vector3 spawnPos = Player.position + direction * 0.5f;
-                // 오브젝트 생성 / 회전 적용
-                GameObject axe = Instantiate(_axePrefab, spawnPos, Quaternion.Euler(0f, 0f, angle));
-                // 공격력 정보를 가져와 적용
-                axe.GetComponent<Attack>()?.SetDamage(_playerScript.Stats.CurrentAtk);
-
-
-                // 일정 시간 동안 플레이어를 따라감
-                float elapsed = 0f;
-                float duration = 0.4f;
-                while (elapsed < duration)
-                {
-                    if (axe == null || Player == null) break;
-
-                    axe.transform.position = Player.position + direction * 1f;
-                    axe.transform.rotation = Quaternion.Euler(0f, 0f, angle);
-
-                    elapsed += Time.deltaTime;
-                    yield return null;
-                }
-                // 오브젝트 제거
-                Destroy(axe);
-            }
-
-            // 공격속도가 높아질수록 딜레이가 짧아짐
-            yield return new WaitForSeconds(GetAttackDelay());
-        }
+        return AttackRoutine(_axePrefab, 0.4f, 1f);
     }
+
     public IEnumerator Sword()
     {
-        // 무한 반복
-        while (true)
-        {
-            if (_playerScript != null && _playerScript.isDead) // 플레이 사망 시 멈춤
-                yield break;
-
-            if (_axePrefab != null)
-            {
-                // 커서 위치를 월드 좌표로 변환
-                Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());
-                mouseWorldPos.z = 0f;
-                // 방향 계산 마우스>플레이어
-                Vector3 direction = (mouseWorldPos - Player.position);
-                if (direction.sqrMagnitude < 0.01f) direction = Vector3.right;
-                direction.Normalize();
-                // 방향에 따라 z 축으로 회전
-                float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
-                // 플레이어와 공격 오브젝트의 거리
-                Vector3 spawnPos = Player.position + direction * 0.5f;
-                // 오브젝트 생성 / 회전 적용
-                GameObject sword = Instantiate(_swordPrefab, spawnPos, Quaternion.Euler(0f, 0f, angle));
-                // 공격력 정보를 가져와 적용
-                sword.GetComponent<Attack>()?.SetDamage(_playerScript.Stats.CurrentAtk);
-
-
-                // 일정 시간 동안 플레이어를 따라감
-                float elapsed = 0f;
-                float duration = 0.2f;
-                while (elapsed < duration)
-                {
-                    if (sword == null || Player == null) break;
-                    sword.transform.position = Player.position + direction * 1f;
-                    sword.transform.rotation = Quaternion.Euler(0f, 0f, angle);
-                    elapsed += Time.deltaTime;
-                    yield return null;
-                }
-                // 오브젝트 제거
-                Destroy(sword);
-            }
-
-            // 공격속도가 높아질수록 딜레이가 짧아짐
-            yield return new WaitForSeconds(GetAttackDelay());
-        }
+        return AttackRoutine(_swordPrefab, 0.2f, 1f);
     }
+
     public IEnumerator Fire()
     {
-        // 무한 반복
+        return AttackRoutine(_bulletPrefab, 0.7f, 0.5f);
+    }
+
+    private IEnumerator AttackRoutine(GameObject prefab, float duration, float offset)
+    {
         while (true)
         {
-            if (_playerScript != null && _playerScript.isDead) // 플레이 사망 시 멈춤
-                yield break;
-
-            if (_axePrefab != null)
+            if (_player != null && _player.IsDead)
             {
-                // 커서 위치를 월드 좌표로 변환
+                yield break;
+            }
+
+            if (prefab != null)
+            {
                 Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());
                 mouseWorldPos.z = 0f;
-                // 방향 계산 마우스>플레이어
+
                 Vector3 direction = (mouseWorldPos - Player.position);
-                if (direction.sqrMagnitude < 0.01f) direction = Vector3.right;
+                if (direction.sqrMagnitude < 0.01f)
+                {
+                    direction = Vector3.right;
+                }
                 direction.Normalize();
-                // 방향에 따라 z 축으로 회전
+
                 float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
-                // 플레이어와 공격 오브젝트의 거리
                 Vector3 spawnPos = Player.position + direction * 0.5f;
-                // 오브젝트 생성 / 회전 적용
-                GameObject bullet = Instantiate(_bulletPrefab, spawnPos, Quaternion.Euler(0f, 0f, angle));
-                // 공격력 정보를 가져와 적용
-                bullet.GetComponent<Attack>()?.SetDamage(_playerScript.Stats.CurrentAtk);
 
+                GameObject instance = Instantiate(prefab, spawnPos, Quaternion.Euler(0f, 0f, angle));
+                instance.GetComponent<Attack>()?.SetDamage(_player.Stats.CurrentAtk);
 
-                // 일정 시간 동안 플레이어를 따라감
                 float elapsed = 0f;
-                float duration = 0.7f; // 공격 유지시간
                 while (elapsed < duration)
                 {
-                    if (bullet == null || Player == null) break;
-                    bullet.transform.position = Player.position + direction * 0.5f; // 오브젝트가 생성 될 거리
-                    bullet.transform.rotation = Quaternion.Euler(0f, 0f, angle);
+                    if (instance == null || Player == null)
+                    {
+                        break;
+                    }
+
+                    instance.transform.position = Player.position + direction * offset;
+                    instance.transform.rotation = Quaternion.Euler(0f, 0f, angle);
+
                     elapsed += Time.deltaTime;
                     yield return null;
                 }
-                // 오브젝트 제거
-                Destroy(bullet);
+
+                Destroy(instance);
             }
 
-            // 공격속도가 높아질수록 딜레이가 짧아짐
             yield return new WaitForSeconds(GetAttackDelay());
         }
     }
+
     private float GetAttackDelay()
     {
-        float atkSpeed = _playerScript.Stats.AtkSpd;
+        float atkSpeed = _player.Stats.AtkSpd;
         if (atkSpeed <= 0.01f)
         {
-            // 공격속도가 비정상이면 자동으로 5로 맞춤
-            atkSpeed = 5f;
+            atkSpeed = 5f; // 최소 공격속도 보정
         }
         return 1f / atkSpeed;
     }
 }
+

--- a/Assets/JDW/Assets/Scenes/Player/Script/CrossHairController (1).cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/CrossHairController (1).cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CrossHairController : MonoBehaviour
+{
+    private void Update()
+    {
+        MoveToMousePos();
+    }
+
+    private void MoveToMousePos()
+    {
+        Vector3 mousePos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+        mousePos.z = 0;
+
+        transform.position = mousePos;
+    }
+}

--- a/Assets/JDW/Assets/Scenes/Player/Script/CrossHairController (1).cs.meta
+++ b/Assets/JDW/Assets/Scenes/Player/Script/CrossHairController (1).cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e430981b2b847c48a97f14573053239
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JDW/Assets/Scenes/Player/Script/CursorDirectionController (1).cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/CursorDirectionController (1).cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CursorDirectionController : MonoBehaviour
+{
+    [SerializeField] private Transform player;       // 플레이어 Transform
+    [SerializeField] private float distance = 2f;    // 플레이어와의 거리
+
+    private void Update()
+    {
+        RotateToMousePos();
+    }
+
+    private void RotateToMousePos()
+    {
+        Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+        mouseWorldPos.z = 0f;
+
+        // 1. 방향 벡터 계산
+        Vector3 dir = (mouseWorldPos - player.position).normalized;
+
+        // 2. 플레이어 기준 위치 이동
+        transform.position = player.position + dir * distance;
+
+        // 3. 회전: 삼각형이 마우스를 바라보도록
+        float angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
+        transform.rotation = Quaternion.Euler(0f, 0f, angle - 90f); // 스프라이트가 위를 바라보고 있어서 보정 -90도
+    }
+}

--- a/Assets/JDW/Assets/Scenes/Player/Script/CursorDirectionController (1).cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/CursorDirectionController (1).cs
@@ -1,11 +1,11 @@
-using System.Collections;
+ï»¿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
 public class CursorDirectionController : MonoBehaviour
 {
-    [SerializeField] private Transform player;       // ÇÃ·¹ÀÌ¾î Transform
-    [SerializeField] private float distance = 2f;    // ÇÃ·¹ÀÌ¾î¿ÍÀÇ °Å¸®
+    [SerializeField] private Transform _player;       // í”Œë ˆì´ì–´ Transform
+    [SerializeField] private float _distance = 2f;    // í”Œë ˆì´ì–´ì™€ì˜ ê±°ë¦¬
 
     private void Update()
     {
@@ -17,14 +17,14 @@ public class CursorDirectionController : MonoBehaviour
         Vector3 mouseWorldPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
         mouseWorldPos.z = 0f;
 
-        // 1. ¹æÇâ º¤ÅÍ °è»ê
-        Vector3 dir = (mouseWorldPos - player.position).normalized;
+        // 1. ë°©í–¥ ë²¡í„° ê³„ì‚°
+        Vector3 dir = (mouseWorldPos - _player.position).normalized;
 
-        // 2. ÇÃ·¹ÀÌ¾î ±âÁØ À§Ä¡ ÀÌµ¿
-        transform.position = player.position + dir * distance;
+        // 2. í”Œë ˆì´ì–´ ê¸°ì¤€ ìœ„ì¹˜ ì´ë™
+        transform.position = _player.position + dir * _distance;
 
-        // 3. È¸Àü: »ï°¢ÇüÀÌ ¸¶¿ì½º¸¦ ¹Ù¶óº¸µµ·Ï
+        // 3. íšŒì „: ì‚¼ê°í˜•ì´ ë§ˆìš°ìŠ¤ë¥¼ ë°”ë¼ë³´ë„ë¡
         float angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
-        transform.rotation = Quaternion.Euler(0f, 0f, angle - 90f); // ½ºÇÁ¶óÀÌÆ®°¡ À§¸¦ ¹Ù¶óº¸°í ÀÖ¾î¼­ º¸Á¤ -90µµ
+        transform.rotation = Quaternion.Euler(0f, 0f, angle - 90f); // ìŠ¤í”„ë¼ì´íŠ¸ê°€ ìœ„ë¥¼ ë°”ë¼ë³´ê³  ìˆì–´ì„œ ë³´ì • -90ë„
     }
 }

--- a/Assets/JDW/Assets/Scenes/Player/Script/CursorDirectionController (1).cs.meta
+++ b/Assets/JDW/Assets/Scenes/Player/Script/CursorDirectionController (1).cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63af3060ea3e83c4b809c779f5c090c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JDW/Assets/Scenes/Player/Script/PlayerConfig.cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/PlayerConfig.cs
@@ -22,6 +22,7 @@ namespace ProjectVS
         public Timer timer;
         public Scanner scanner;
         public PlayerDataManager playerDataManager;
+        public AttackPosition attackPosition;
 
         public bool isDead = false;
 
@@ -122,6 +123,24 @@ namespace ProjectVS
             if (GameManager.Instance != null)
                 GameManager.Instance.SavePlayerStats(Stats);
         }
-       
+        public void ApplyStatsFromData(CharacterSelectionDataClass data, int classIndex)
+        {
+            Stats = new PlayerStats(1, selectedClass, data.HP, data.Attack, data.Defense, data.MoveSpeed, data.AttackSpeed);
+            Stats.CurrentHp = data.HP;
+            UpdateHpBar();
+
+            // 공격 위치 설정
+            attackPosition = GetComponentInChildren<AttackPosition>();
+            if (attackPosition != null)
+            {
+                switch (classIndex)
+                {
+                    case 0: attackPosition.SwitchCoroutine(attackPosition.Axe()); break;
+                    case 1: attackPosition.SwitchCoroutine(attackPosition.Sword()); break;
+                    case 2: attackPosition.SwitchCoroutine(attackPosition.Fire()); break;
+                }
+            }
+        }
+
     }
 }

--- a/Assets/JDW/Assets/Scenes/Player/Script/PlayerMove.cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/PlayerMove.cs
@@ -2,59 +2,58 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Tilemaps;
-using UnityEngine.UIElements;
 using UnityEngine.InputSystem;
 using ProjectVS;
 
 public class PlayerMove : MonoBehaviour
 {
 
-    private Rigidbody2D rigid;
-    public Vector2 MoveInput;
-    public Animator anim;
-    public MapSwitcher mapSwitcher;
-
-    private PlayerAction inputActions;
-
-    public FadeManager fadeManager;
-    public Timer timer;
-
+    private Rigidbody2D _rigid;
+    private Animator _anim;
     private PlayerConfig _player;
+    private PlayerAction _inputActions;
+
+    public Vector2 MoveInput { get; private set; }
+        
+    public MapSwitcher MapSwitcher;
+    public FadeManager Fade;
   
     private void Awake()
     {
-        rigid = GetComponent<Rigidbody2D>();
-        anim = GetComponent<Animator>();
+        _rigid = GetComponent<Rigidbody2D>();
+        _anim = GetComponent<Animator>();
         _player = GetComponent<PlayerConfig>();
 
-        inputActions = new PlayerAction();
-        inputActions.Player.Move.performed += ctx => MoveInput = ctx.ReadValue<Vector2>();
-        inputActions.Player.Move.canceled += ctx => MoveInput = Vector2.zero;
+        _inputActions = new PlayerAction();
+        _inputActions.Player.Move.performed += ctx => MoveInput = ctx.ReadValue<Vector2>();
+        _inputActions.Player.Move.canceled += ctx => MoveInput = Vector2.zero;
     }
+
     void Start()
     {
-        if (mapSwitcher == null)
-            mapSwitcher = FindObjectOfType<MapSwitcher>();
+        if (MapSwitcher == null)// 맵스위처 자동 할당
+            MapSwitcher = FindObjectOfType<MapSwitcher>();
     }
     private void OnEnable()
     {
-        inputActions.Enable();
+        _inputActions.Enable();
     }
     private void OnDisable()
     {
-        inputActions.Disable();
+        _inputActions.Disable();
     }
     private void FixedUpdate()
     {
-        playerMove();
+        MovePlayer();
     }
-    public void playerMove()
+    public void MovePlayer()
     {
-        // rigidbody를 통해 이동 , 게임 매니저를 통해 player의 move값을 가져옴
-        rigid.velocity = MoveInput.normalized * _player.Stats.CurrentSpd;
-        // 이동 애니메이션, 이동시 IsWalking을 ture로 바꿈
-        bool IsWalking = MoveInput != Vector2.zero;
-        anim.SetBool("IsWalking", IsWalking);
+        // rigidbody를 통해 이동
+        _rigid.velocity = MoveInput.normalized * _player.Stats.CurrentSpd;
+
+        // 이동 애니메이션 상태 설정
+        bool isWalking = MoveInput != Vector2.zero;
+        _anim.SetBool("IsWalking", isWalking);
     }
     private void OnTriggerEnter2D(Collider2D other)
     {
@@ -62,15 +61,14 @@ public class PlayerMove : MonoBehaviour
         {
             Debug.Log("상점을 나감");
             StartCoroutine(HandleFadeTransition());
-            // TODO : 씬전환으로 진행할경우 코드추가
+            // TODO : 씬 전환 필요 시 처리 추가
         }
     }
     private IEnumerator HandleFadeTransition()
     {
-        yield return StartCoroutine(fadeManager.FadeOut()); // 페이드 아웃
-        mapSwitcher.OnBattleField();  
-        
-        yield return StartCoroutine(fadeManager.FadeIn());
+        yield return StartCoroutine(Fade.FadeOut()); // 페이드 아웃
+        MapSwitcher.OnBattleField();  
+        yield return StartCoroutine(Fade.FadeIn());
         
     }
    

--- a/Assets/JDW/Assets/Scenes/Player/Script/PlayerSpawner.cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/PlayerSpawner.cs
@@ -4,7 +4,9 @@ using ProjectVS;
 
 using UnityEngine;
 using UnityEngine.InputSystem;
-
+using ProjectVS.CharacterSelectionData.CharacterSelectionDataParser;
+using CharacterSelectionDataClass = ProjectVS.CharacterSelectionData.CharacterSelectionData.CharacterSelectionData;
+using ProjectVS.Utils.CsvTable;
 public class PlayerSpawner : MonoBehaviour 
 {
     [HideInInspector] public PlayerConfig Player;
@@ -17,9 +19,14 @@ public class PlayerSpawner : MonoBehaviour
 
     private PlayerAction inputActions;
     private GameObject currentPlayerInstance;
+    private List<CharacterSelectionDataClass> characterDataList;
 
     private void Awake()
     {
+        //TSV 데이터 불러옴
+        CsvTable table = new CsvTable("Min/Resources/CharacterSelectionData.tsv", '\t');
+        characterDataList = CharacterSelectionDataParser.Parse(table);
+
         inputActions = new PlayerAction();
         inputActions.CharacterSelect.Enable();
         inputActions.CharacterSelect.SelectClass.performed += OnClassSelect;
@@ -59,20 +66,23 @@ public class PlayerSpawner : MonoBehaviour
             Debug.LogError("AttackPosition 컴포넌트가 프리팹에 없음!");
             return;
         }
+        if (index < characterDataList.Count)
+        {
+            Player.ApplyStatsFromData(characterDataList[index]);
+        }
+        else
+        {
+            Debug.LogWarning("TSV 데이터에 해당 인덱스 정보가 없습니다.");
+        }
 
         // 번호에 따라 공격 코루틴 자동 실행
         switch (index)
         {
-            case 0:
-                attackPosition.SwitchCoroutine(attackPosition.Axe());
-                break;
-            case 1:
-                attackPosition.SwitchCoroutine(attackPosition.Sword());
-                break;
-            case 2:
-                attackPosition.SwitchCoroutine(attackPosition.Fire());
-                break;
+            case 0: attackPosition.SwitchCoroutine(attackPosition.Axe()); break;
+            case 1: attackPosition.SwitchCoroutine(attackPosition.Sword()); break;
+            case 2: attackPosition.SwitchCoroutine(attackPosition.Fire()); break;
         }
+    
         CurrentClassIndex = index;
     }
 }

--- a/Assets/JDW/Assets/Scenes/Player/Script/PlayerSpawner.cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/PlayerSpawner.cs
@@ -7,37 +7,38 @@ using UnityEngine.InputSystem;
 using ProjectVS.CharacterSelectionData.CharacterSelectionDataParser;
 using CharacterSelectionDataClass = ProjectVS.CharacterSelectionData.CharacterSelectionData.CharacterSelectionData;
 using ProjectVS.Utils.CsvTable;
-public class PlayerSpawner : MonoBehaviour 
+public class PlayerSpawner : MonoBehaviour
 {
-    [HideInInspector] public PlayerConfig Player;
-    [HideInInspector] public PlayerMove playerMove;
-
     public GameObject[] playerPrefabs; // 0 = 검, 1 = 도끼, 2 = 마법
     public Transform playerSpawnPoint;
+
     public int CurrentClassIndex { get; private set; }
 
-    private PlayerAction inputActions;
-    private GameObject currentPlayerInstance;
-    private List<CharacterSelectionDataClass> characterDataList;// TSV에서 파싱된 캐릭터 정보
+    private PlayerAction _inputActions; // 입력 처리용 액션
+    private GameObject _currentPlayerInstance;
+    private List<CharacterSelectionDataClass> _characterDataList;// TSV에서 파싱된 캐릭터 정보
 
     private void Awake()
     {
-        //TSV 데이터 불러옴
+        // TSV 데이터 불러옴
         CsvTable table = new CsvTable("Min/Resources/CharacterSelectionData.tsv", '\t');
-        characterDataList = CharacterSelectionDataParser.Parse(table);
+        _characterDataList = CharacterSelectionDataParser.Parse(table);
 
-        inputActions = new PlayerAction(); // 인풋액션 등록
-        inputActions.CharacterSelect.Enable();
-        inputActions.CharacterSelect.SelectClass.performed += OnClassSelect;
+        _inputActions = new PlayerAction(); // 인풋액션 등록
+        _inputActions.CharacterSelect.Enable();
+        _inputActions.CharacterSelect.SelectClass.performed += OnClassSelect;
      
     }
     private void OnDestroy()
     {
-        inputActions.CharacterSelect.SelectClass.performed -= OnClassSelect; // 한번 입력후 이벤트 해제
+        _inputActions.CharacterSelect.SelectClass.performed -= OnClassSelect; // 한번 입력후 이벤트 해제
     }
     private void OnClassSelect(InputAction.CallbackContext ctx)
     {
-        if (currentPlayerInstance != null) return; // 이미 플레이어가 생성되었으면 무시
+        if (_currentPlayerInstance != null)
+        {
+            return; // 이미 플레이어가 생성되었으면 무시
+        }
 
         string key = ctx.control.displayName; // 입력된 키 문자열 ("1", "2", "3")
         int index = -1;
@@ -53,15 +54,16 @@ public class PlayerSpawner : MonoBehaviour
         if (index >= 0 && index < playerPrefabs.Length)
             SpawnPlayer(index); // 해당 인덱스의 클래스 생성
     }
+
     private void SpawnPlayer(int index)
     {
         // 프리팹 생성
         GameObject newPlayer = Instantiate(playerPrefabs[index], playerSpawnPoint.position, Quaternion.identity);
         // playerConfig 컴포넌트 가져옴
         PlayerConfig config = newPlayer.GetComponent<PlayerConfig>();
-        if (config != null && index < characterDataList.Count)
+        if (config != null && index < _characterDataList.Count)
         {
-            config.ApplyStatsFromData(characterDataList[index], index);// TSV와 클래스 정보 공격방식을 적용
+            config.ApplyStatsFromData(_characterDataList[index], index);// TSV와 클래스 정보 공격방식을 적용
         }
         // 현재 클래스 인덱스 저장
         CurrentClassIndex = index;

--- a/Assets/JDW/Assets/Scenes/Player/Script/PlayerStats.cs
+++ b/Assets/JDW/Assets/Scenes/Player/Script/PlayerStats.cs
@@ -14,6 +14,11 @@ public class PlayerStats : UnitStats
 
     // 골드 데이터는 PlayerData 클래스로 이전됩니다.
     // public int Gold = 0;                    
+    public float BaseAtk;
+    public float BaseDfs;
+    public float BaseMaxHp;
+    public float BaseAtkSpd;
+    public float BaseSpd;
 
     public bool AddExp(float amount)
     {
@@ -115,4 +120,5 @@ public class PlayerStats : UnitStats
         Level = level;
         CharacterClass = charClass;
     }
+
 }

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerAxe.prefab
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerAxe.prefab
@@ -118,6 +118,7 @@ Transform:
   - {fileID: 1160467246660412003}
   - {fileID: 846167591246401027}
   - {fileID: 8631893079969755089}
+  - {fileID: 8407538516562970802}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &8930400971873860480
@@ -318,6 +319,11 @@ MonoBehaviour:
     CharacterClass: 2
     CurrentExp: 0
     MaxExp: 0
+    BaseAtk: 0
+    BaseDfs: 0
+    BaseMaxHp: 0
+    BaseAtkSpd: 0
+    BaseSpd: 0
   timer: {fileID: 7439314377194012607, guid: e751d69887daeff448c05c857ec5922e, type: 3}
   scanner: {fileID: 0}
   playerData:
@@ -332,6 +338,11 @@ MonoBehaviour:
       CharacterClass: 0
       CurrentExp: 0
       MaxExp: 100
+      BaseAtk: 0
+      BaseDfs: 0
+      BaseMaxHp: 0
+      BaseAtkSpd: 0
+      BaseSpd: 0
     InventoryItems: []
     CurrentStage: 0
     MonstersDefeated: 0
@@ -636,6 +647,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: HPbarZone (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 2871611994248855719, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -736,6 +751,22 @@ PrefabInstance:
       propertyPath: FollowUpImage
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 7299295138209099044, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7574037192109061622, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8674770012350155428, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8691946067640454278, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8858386848036931505, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
@@ -761,4 +792,74 @@ MonoBehaviour:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
   m_PrefabInstance: {fileID: 4960086530428258843}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7869289486881793206
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5327371813207693605}
+    m_Modifications:
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.7576582
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5874513840534949430, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_Name
+      value: CursorPointer
+      objectReference: {fileID: 0}
+    - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 5327371813207693605}
+    - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: distance
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+--- !u!4 &8407538516562970802 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+  m_PrefabInstance: {fileID: 7869289486881793206}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerAxe.prefab
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerAxe.prefab
@@ -278,11 +278,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a38afd9017f7565458e944c8818215cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MoveInput: {x: 0, y: 0}
-  anim: {fileID: 8930400971873860480}
-  mapSwitcher: {fileID: 0}
-  fadeManager: {fileID: 1705760944804791855, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
-  timer: {fileID: 7439314377194012607, guid: e751d69887daeff448c05c857ec5922e, type: 3}
+  MapSwitcher: {fileID: 0}
+  Fade: {fileID: 0}
 --- !u!114 &8915004436936648237
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -307,7 +304,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c920a0eeb513d54aa4ce5e43b6c8054, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectedClass: 2
+  SelectedClass: 0
   Stats:
     _hp: 0
     _baseMaxHp: 0
@@ -324,36 +321,13 @@ MonoBehaviour:
     BaseMaxHp: 0
     BaseAtkSpd: 0
     BaseSpd: 0
-  timer: {fileID: 7439314377194012607, guid: e751d69887daeff448c05c857ec5922e, type: 3}
-  scanner: {fileID: 0}
-  playerData:
-    Stats:
-      _hp: 0
-      _baseMaxHp: 0
-      _baseAtk: 0
-      _baseDfs: 0
-      _baseSpd: 0
-      _baseAtkSpd: 0
-      Level: 1
-      CharacterClass: 0
-      CurrentExp: 0
-      MaxExp: 100
-      BaseAtk: 0
-      BaseDfs: 0
-      BaseMaxHp: 0
-      BaseAtkSpd: 0
-      BaseSpd: 0
-    InventoryItems: []
-    CurrentStage: 0
-    MonstersDefeated: 0
-    Gold: 0
-    Diamonds: 0
-    CurrentAffinityExp: 0
-    CurrentAffinityLevel: 0
-    WornCostumeName: 
-  isDead: 0
+  Timer: {fileID: 0}
+  Scanner: {fileID: 0}
+  PlayerDataManager: {fileID: 0}
+  AttackPosition: {fileID: 0}
+  IsDead: 0
   _hpBar: {fileID: 2827814678606631806}
-  inventory: []
+  Inventory: []
 --- !u!114 &5786611776289020374
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -847,6 +821,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
       propertyPath: player
+      value: 
+      objectReference: {fileID: 5327371813207693605}
+    - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: _player
       value: 
       objectReference: {fileID: 5327371813207693605}
     - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerAxe.prefab
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerAxe.prefab
@@ -345,108 +345,6 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 262144
   nearestTarget: {fileID: 0}
---- !u!1 &3443636245554196259
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8631893079969755089}
-  - component: {fileID: 4579917235854000464}
-  - component: {fileID: 5009183800584346662}
-  - component: {fileID: 4513316934970346899}
-  m_Layer: 5
-  m_Name: Canvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8631893079969755089
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3443636245554196259}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 1.4479324}
-  m_LocalScale: {x: 1.4479324, y: 1.4479324, z: 1.4479324}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8194548807542123437}
-  m_Father: {fileID: 5327371813207693605}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 1390.015, y: 781.8835}
-  m_SizeDelta: {x: 1920, y: 1080}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!223 &4579917235854000464
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3443636245554196259}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 2
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &5009183800584346662
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3443636245554196259}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
---- !u!114 &4513316934970346899
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3443636245554196259}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!1 &5919637639147977788
 GameObject:
   m_ObjectHideFlags: 0
@@ -609,164 +507,6 @@ MonoBehaviour:
   _axePrefab: {fileID: 1476766215471760246, guid: a28979e937bef6e49852b0b24dab1a03, type: 3}
   _bulletPrefab: {fileID: 2418890576715569026, guid: c18e72a2d75595f459f7497f27fccc53, type: 3}
   _muzzlePos: {fileID: 846167591246401027}
---- !u!1001 &4960086530428258843
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 8631893079969755089}
-    m_Modifications:
-    - target: {fileID: 1687213935205963161, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_Name
-      value: HPbarZone (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 2871611994248855719, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -840
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 30
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.0010529427
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.0037730446
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.0023398725
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -960
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0.9176636
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7200039867611060581, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: currentValue
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7200039867611060581, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: FollowUpImage
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7299295138209099044, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7574037192109061622, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8674770012350155428, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8691946067640454278, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8858386848036931505, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 7166371230185166899, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
---- !u!114 &2827814678606631806 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7200039867611060581, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-  m_PrefabInstance: {fileID: 4960086530428258843}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 23926a052ffbd914e9b3faa0ed5f822f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &8194548807542123437 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-  m_PrefabInstance: {fileID: 4960086530428258843}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7869289486881793206
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -840,4 +580,121 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
   m_PrefabInstance: {fileID: 7869289486881793206}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8923086239762987822
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5327371813207693605}
+    m_Modifications:
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1920
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1080
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.784
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4925259989204597374, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 4736911263509308453}
+    - target: {fileID: 6061681559421146125, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_Name
+      value: PlayerUi
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+--- !u!114 &2827814678606631806 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6695517698488821840, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+  m_PrefabInstance: {fileID: 8923086239762987822}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23926a052ffbd914e9b3faa0ed5f822f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8631893079969755089 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+  m_PrefabInstance: {fileID: 8923086239762987822}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerMagic.prefab
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerMagic.prefab
@@ -117,7 +117,7 @@ Transform:
   - {fileID: 4241580183129601620}
   - {fileID: 1160467246660412003}
   - {fileID: 846167591246401027}
-  - {fileID: 8631893079969755089}
+  - {fileID: 5477814865156661155}
   - {fileID: 1307349945565990022}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -326,7 +326,7 @@ MonoBehaviour:
   PlayerDataManager: {fileID: 0}
   AttackPosition: {fileID: 0}
   IsDead: 0
-  _hpBar: {fileID: 2827814678606631806}
+  _hpBar: {fileID: 0}
   Inventory: []
 --- !u!114 &5786611776289020374
 MonoBehaviour:
@@ -345,108 +345,6 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 262144
   nearestTarget: {fileID: 0}
---- !u!1 &3443636245554196259
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8631893079969755089}
-  - component: {fileID: 4579917235854000464}
-  - component: {fileID: 5009183800584346662}
-  - component: {fileID: 4513316934970346899}
-  m_Layer: 5
-  m_Name: Canvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8631893079969755089
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3443636245554196259}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 1.4479324}
-  m_LocalScale: {x: 1.4479324, y: 1.4479324, z: 1.4479324}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8194548807542123437}
-  m_Father: {fileID: 5327371813207693605}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 1390.015, y: 781.8835}
-  m_SizeDelta: {x: 1920, y: 1080}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!223 &4579917235854000464
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3443636245554196259}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 2
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &5009183800584346662
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3443636245554196259}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
---- !u!114 &4513316934970346899
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3443636245554196259}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!1 &5919637639147977788
 GameObject:
   m_ObjectHideFlags: 0
@@ -679,141 +577,117 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
   m_PrefabInstance: {fileID: 845662418691350658}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &4960086530428258843
+--- !u!1001 &4619168424978025308
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 8631893079969755089}
+    m_TransformParent: {fileID: 5327371813207693605}
     m_Modifications:
-    - target: {fileID: 1687213935205963161, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_Name
-      value: HPbarZone (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_SizeDelta.x
-      value: -840
+      value: 1920
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 30
+      value: 1080
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.0010529427
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.0037730446
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.0023398725
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -1
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -960
+      value: -0.784
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.9176636
+      value: 1.35
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    - target: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7200039867611060581, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: currentValue
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7200039867611060581, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-      propertyPath: FollowUpImage
+    - target: {fileID: 4925259989204597374, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_Camera
       value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8858386848036931505, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      objectReference: {fileID: 4736911263509308453}
+    - target: {fileID: 5039422586415756932, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6061681559421146125, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: m_Name
+      value: PlayerUi
+      objectReference: {fileID: 0}
+    - target: {fileID: 6695517698488821840, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+      propertyPath: currentValue
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 7166371230185166899, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
---- !u!114 &2827814678606631806 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7200039867611060581, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-  m_PrefabInstance: {fileID: 4960086530428258843}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 23926a052ffbd914e9b3faa0ed5f822f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &8194548807542123437 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+--- !u!224 &5477814865156661155 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
-  m_PrefabInstance: {fileID: 4960086530428258843}
+  m_CorrespondingSourceObject: {fileID: 873573727881680127, guid: 408db3813703cf549aae972ebc597ceb, type: 3}
+  m_PrefabInstance: {fileID: 4619168424978025308}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerMagic.prefab
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerMagic.prefab
@@ -118,6 +118,7 @@ Transform:
   - {fileID: 1160467246660412003}
   - {fileID: 846167591246401027}
   - {fileID: 8631893079969755089}
+  - {fileID: 1307349945565990022}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &8930400971873860480
@@ -318,6 +319,11 @@ MonoBehaviour:
     CharacterClass: 3
     CurrentExp: 0
     MaxExp: 0
+    BaseAtk: 0
+    BaseDfs: 0
+    BaseMaxHp: 0
+    BaseAtkSpd: 0
+    BaseSpd: 0
   timer: {fileID: 7439314377194012607, guid: e751d69887daeff448c05c857ec5922e, type: 3}
   scanner: {fileID: 0}
   playerData:
@@ -332,6 +338,11 @@ MonoBehaviour:
       CharacterClass: 0
       CurrentExp: 0
       MaxExp: 100
+      BaseAtk: 0
+      BaseDfs: 0
+      BaseMaxHp: 0
+      BaseAtkSpd: 0
+      BaseSpd: 0
     InventoryItems: []
     CurrentStage: 0
     MonstersDefeated: 0
@@ -624,6 +635,72 @@ MonoBehaviour:
   _axePrefab: {fileID: 1476766215471760246, guid: a28979e937bef6e49852b0b24dab1a03, type: 3}
   _bulletPrefab: {fileID: 2418890576715569026, guid: c18e72a2d75595f459f7497f27fccc53, type: 3}
   _muzzlePos: {fileID: 846167591246401027}
+--- !u!1001 &845662418691350658
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5327371813207693605}
+    m_Modifications:
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.1625192
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.92682385
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.7576582
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5874513840534949430, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_Name
+      value: CursorPointer
+      objectReference: {fileID: 0}
+    - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 5327371813207693605}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+--- !u!4 &1307349945565990022 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+  m_PrefabInstance: {fileID: 845662418691350658}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4960086530428258843
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerMagic.prefab
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerMagic.prefab
@@ -278,11 +278,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a38afd9017f7565458e944c8818215cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MoveInput: {x: 0, y: 0}
-  anim: {fileID: 8930400971873860480}
-  mapSwitcher: {fileID: 0}
-  fadeManager: {fileID: 1705760944804791855, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
-  timer: {fileID: 7439314377194012607, guid: e751d69887daeff448c05c857ec5922e, type: 3}
+  MapSwitcher: {fileID: 0}
+  Fade: {fileID: 0}
 --- !u!114 &8915004436936648237
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -307,7 +304,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c920a0eeb513d54aa4ce5e43b6c8054, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectedClass: 3
+  SelectedClass: 0
   Stats:
     _hp: 0
     _baseMaxHp: 0
@@ -324,36 +321,13 @@ MonoBehaviour:
     BaseMaxHp: 0
     BaseAtkSpd: 0
     BaseSpd: 0
-  timer: {fileID: 7439314377194012607, guid: e751d69887daeff448c05c857ec5922e, type: 3}
-  scanner: {fileID: 0}
-  playerData:
-    Stats:
-      _hp: 0
-      _baseMaxHp: 0
-      _baseAtk: 0
-      _baseDfs: 0
-      _baseSpd: 0
-      _baseAtkSpd: 0
-      Level: 1
-      CharacterClass: 0
-      CurrentExp: 0
-      MaxExp: 100
-      BaseAtk: 0
-      BaseDfs: 0
-      BaseMaxHp: 0
-      BaseAtkSpd: 0
-      BaseSpd: 0
-    InventoryItems: []
-    CurrentStage: 0
-    MonstersDefeated: 0
-    Gold: 0
-    Diamonds: 0
-    CurrentAffinityExp: 0
-    CurrentAffinityLevel: 0
-    WornCostumeName: 
-  isDead: 0
+  Timer: {fileID: 0}
+  Scanner: {fileID: 0}
+  PlayerDataManager: {fileID: 0}
+  AttackPosition: {fileID: 0}
+  IsDead: 0
   _hpBar: {fileID: 2827814678606631806}
-  inventory: []
+  Inventory: []
 --- !u!114 &5786611776289020374
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -689,6 +663,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
       propertyPath: player
+      value: 
+      objectReference: {fileID: 5327371813207693605}
+    - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: _player
       value: 
       objectReference: {fileID: 5327371813207693605}
     m_RemovedComponents: []

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerSword.prefab
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerSword.prefab
@@ -118,6 +118,7 @@ Transform:
   - {fileID: 1160467246660412003}
   - {fileID: 846167591246401027}
   - {fileID: 8631893079969755089}
+  - {fileID: 2250716333769663426}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &8930400971873860480
@@ -318,6 +319,11 @@ MonoBehaviour:
     CharacterClass: 1
     CurrentExp: 0
     MaxExp: 0
+    BaseAtk: 0
+    BaseDfs: 0
+    BaseMaxHp: 0
+    BaseAtkSpd: 0
+    BaseSpd: 0
   timer: {fileID: 7439314377194012607, guid: e751d69887daeff448c05c857ec5922e, type: 3}
   scanner: {fileID: 0}
   playerData:
@@ -332,6 +338,11 @@ MonoBehaviour:
       CharacterClass: 0
       CurrentExp: 0
       MaxExp: 100
+      BaseAtk: 0
+      BaseDfs: 0
+      BaseMaxHp: 0
+      BaseAtkSpd: 0
+      BaseSpd: 0
     InventoryItems: []
     CurrentStage: 0
     MonstersDefeated: 0
@@ -624,6 +635,76 @@ MonoBehaviour:
   _axePrefab: {fileID: 1476766215471760246, guid: a28979e937bef6e49852b0b24dab1a03, type: 3}
   _bulletPrefab: {fileID: 2418890576715569026, guid: c18e72a2d75595f459f7497f27fccc53, type: 3}
   _muzzlePos: {fileID: 846167591246401027}
+--- !u!1001 &478753959921192902
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5327371813207693605}
+    m_Modifications:
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.1625192
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.92682385
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.7576582
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5874513840534949430, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: m_Name
+      value: CursorPointer
+      objectReference: {fileID: 0}
+    - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 5327371813207693605}
+    - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: distance
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+--- !u!4 &2250716333769663426 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1844442455343672324, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+  m_PrefabInstance: {fileID: 478753959921192902}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4960086530428258843
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerSword.prefab
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerSword.prefab
@@ -278,11 +278,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a38afd9017f7565458e944c8818215cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MoveInput: {x: 0, y: 0}
-  anim: {fileID: 8930400971873860480}
-  mapSwitcher: {fileID: 0}
-  fadeManager: {fileID: 1705760944804791855, guid: 933bb90b50166bf44911b92fa7f0ddda, type: 3}
-  timer: {fileID: 7439314377194012607, guid: e751d69887daeff448c05c857ec5922e, type: 3}
+  MapSwitcher: {fileID: 0}
+  Fade: {fileID: 0}
 --- !u!114 &8915004436936648237
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -307,7 +304,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c920a0eeb513d54aa4ce5e43b6c8054, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectedClass: 1
+  SelectedClass: 0
   Stats:
     _hp: 0
     _baseMaxHp: 0
@@ -324,36 +321,13 @@ MonoBehaviour:
     BaseMaxHp: 0
     BaseAtkSpd: 0
     BaseSpd: 0
-  timer: {fileID: 7439314377194012607, guid: e751d69887daeff448c05c857ec5922e, type: 3}
-  scanner: {fileID: 0}
-  playerData:
-    Stats:
-      _hp: 0
-      _baseMaxHp: 0
-      _baseAtk: 0
-      _baseDfs: 0
-      _baseSpd: 0
-      _baseAtkSpd: 0
-      Level: 1
-      CharacterClass: 0
-      CurrentExp: 0
-      MaxExp: 100
-      BaseAtk: 0
-      BaseDfs: 0
-      BaseMaxHp: 0
-      BaseAtkSpd: 0
-      BaseSpd: 0
-    InventoryItems: []
-    CurrentStage: 0
-    MonstersDefeated: 0
-    Gold: 0
-    Diamonds: 0
-    CurrentAffinityExp: 0
-    CurrentAffinityLevel: 0
-    WornCostumeName: 
-  isDead: 0
+  Timer: {fileID: 0}
+  Scanner: {fileID: 0}
+  PlayerDataManager: {fileID: 0}
+  AttackPosition: {fileID: 0}
+  IsDead: 0
   _hpBar: {fileID: 2827814678606631806}
-  inventory: []
+  Inventory: []
 --- !u!114 &5786611776289020374
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -689,6 +663,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
       propertyPath: player
+      value: 
+      objectReference: {fileID: 5327371813207693605}
+    - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}
+      propertyPath: _player
       value: 
       objectReference: {fileID: 5327371813207693605}
     - target: {fileID: 8994524319637365489, guid: 874599626ceb8ca4e9f83e8ffed726fb, type: 3}

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerUi.prefab
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerUi.prefab
@@ -1,0 +1,255 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6061681559421146125
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 873573727881680127}
+  - component: {fileID: 4925259989204597374}
+  - component: {fileID: 4490398379352205064}
+  - component: {fileID: 5005661368890046141}
+  m_Layer: 5
+  m_Name: PlayerUi
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &873573727881680127
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6061681559421146125}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 0.0016134952, y: 0.005708748, z: 0.0016134952}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 751477790999154819}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -0.784, y: 1.35}
+  m_SizeDelta: {x: 1920, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &4925259989204597374
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6061681559421146125}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &4490398379352205064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6061681559421146125}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &5005661368890046141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6061681559421146125}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1001 &4539892048951505205
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 873573727881680127}
+    m_Modifications:
+    - target: {fileID: 1687213935205963161, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_Name
+      value: HPbarZone (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1687213935205963161, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2871611994248855719, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7200039867611060581, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: currentValue
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7200039867611060581, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: FollowUpImage
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7299295138209099044, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7574037192109061622, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8674770012350155428, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8691946067640454278, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8858386848036931505, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7166371230185166899, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+--- !u!224 &751477790999154819 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3849775940481999286, guid: 699256066dd06fb478cb0f48dfb16843, type: 3}
+  m_PrefabInstance: {fileID: 4539892048951505205}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/JDW/Assets/Scenes/Prefab/PlayerUi.prefab.meta
+++ b/Assets/JDW/Assets/Scenes/Prefab/PlayerUi.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 408db3813703cf549aae972ebc597ceb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JDW/Assets/Scenes/Test/Ax.prefab
+++ b/Assets/JDW/Assets/Scenes/Test/Ax.prefab
@@ -30,14 +30,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1476766215471760246}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: 0, w: -1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.8, y: -0.00000080391, z: 0}
   m_LocalScale: {x: 2.4426901, y: 5.9923873, z: 2.0952404}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3105910173103397822}
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &3430098972871949281
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -116,7 +116,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!61 &6946014322182539346
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -239,13 +239,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8992924548427270240}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0.53638935, w: 0.84397066}
-  m_LocalPosition: {x: -0.173, y: -0.033, z: -0.49831817}
-  m_LocalScale: {x: 1.027078, y: 1.3514711, z: 1.4205661}
+  m_LocalRotation: {x: -0, y: -0, z: -0.400432, w: 0.9163265}
+  m_LocalPosition: {x: -0.06, y: -0.048, z: 0}
+  m_LocalScale: {x: 1.0233612, y: 1.1384523, z: 1.4205661}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8919685519990624475}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -64.876}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -47.21}
 --- !u!95 &190313214432112393
 Animator:
   serializedVersion: 5

--- a/Assets/JDW/Assets/Scenes/Test/Boss.cs
+++ b/Assets/JDW/Assets/Scenes/Test/Boss.cs
@@ -1,4 +1,5 @@
 ﻿using ProjectVS;
+using ProjectVS.Manager;
 
 using UnityEngine;
 
@@ -41,8 +42,8 @@ public class Boss : MonoBehaviour
             if (player != null)
             {
                 player.ExpUp(_exp);
-                player.playerDataManager.gold += _gold;
-                Debug.Log($"골드 흭득 : {_gold}, 현재 골드 : {player.playerDataManager.gold}");
+                PlayerDataManager.Instance.gold += _gold;
+                Debug.Log($"골드 흭득 : {_gold}, 현재 골드 : {player.PlayerDataManager.gold}");
                 _timer.ResumeTimer();
                 _timer.SetMessage("");
             }

--- a/Assets/JDW/Assets/Scenes/Test/Boss.cs
+++ b/Assets/JDW/Assets/Scenes/Test/Boss.cs
@@ -41,8 +41,8 @@ public class Boss : MonoBehaviour
             if (player != null)
             {
                 player.ExpUp(_exp);
-                player.playerData.Gold += _gold;
-                Debug.Log($"골드 흭득 : {_gold}, 현재 골드 : {player.playerData.Gold}");
+                player.playerDataManager.gold += _gold;
+                Debug.Log($"골드 흭득 : {_gold}, 현재 골드 : {player.playerDataManager.gold}");
                 _timer.ResumeTimer();
                 _timer.SetMessage("");
             }

--- a/Assets/JDW/Assets/Scenes/Test/Sword.prefab
+++ b/Assets/JDW/Assets/Scenes/Test/Sword.prefab
@@ -102,7 +102,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0960422e503d19344830eeabd7e735dd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hitbox: {fileID: 0}
   _rigid: {fileID: 3990077426810671669}
   FirePower: 10
 --- !u!50 &3990077426810671669

--- a/Assets/JDW/Assets/Scenes/Ui/BarBG.prefab
+++ b/Assets/JDW/Assets/Scenes/Ui/BarBG.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8032206246652331213
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5152237786287241119}
+  - component: {fileID: 2610534500159174204}
+  - component: {fileID: 3772345128412472674}
+  m_Layer: 5
+  m_Name: BarBG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5152237786287241119
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8032206246652331213}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 9, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 15, y: 0}
+  m_SizeDelta: {x: 115, y: 24}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &2610534500159174204
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8032206246652331213}
+  m_CullTransparentMesh: 1
+--- !u!114 &3772345128412472674
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8032206246652331213}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: eadcebcc04cf0b04ab81525a6425ce09, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/JDW/Assets/Scenes/Ui/BarBG.prefab.meta
+++ b/Assets/JDW/Assets/Scenes/Ui/BarBG.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 29cb71f9f4f113449910f16377ddc252
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JDW/Assets/Scenes/Ui/BossHPbarZone (1).prefab
+++ b/Assets/JDW/Assets/Scenes/Ui/BossHPbarZone (1).prefab
@@ -1,0 +1,587 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &661962349118163734
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2048201407022927467}
+  - component: {fileID: 1859879642100506938}
+  m_Layer: 5
+  m_Name: BossHPbarZone (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2048201407022927467
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 661962349118163734}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3904323940263915134}
+  - {fileID: 6698612592391412951}
+  - {fileID: 4736431474040562949}
+  - {fileID: 1912900429506284773}
+  - {fileID: 6024049827191089538}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 70}
+  m_SizeDelta: {x: -840, y: 30}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &1859879642100506938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 661962349118163734}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23926a052ffbd914e9b3faa0ed5f822f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MaxValue: 100
+  MinValue: 0
+  currentValue: 100
+  AnimationSpeed: 2
+  FillImage: {fileID: 1632848933924881357}
+  FollowUpImage: {fileID: 1305832796103675322}
+  FillPadding: 0
+  Mode: 0
+--- !u!1 &1979885156307308411
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6698612592391412951}
+  - component: {fileID: 3307785595420799081}
+  - component: {fileID: 3361941308382115496}
+  - component: {fileID: 5822793395975201654}
+  m_Layer: 5
+  m_Name: FillHPMask
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6698612592391412951
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979885156307308411}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 9, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3071892659551274024}
+  m_Father: {fileID: 2048201407022927467}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 120, y: 24}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &3307785595420799081
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979885156307308411}
+  m_CullTransparentMesh: 1
+--- !u!114 &3361941308382115496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979885156307308411}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: eadcebcc04cf0b04ab81525a6425ce09, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5822793395975201654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979885156307308411}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
+--- !u!1 &5212749226945669879
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1912900429506284773}
+  - component: {fileID: 5544051856517773553}
+  - component: {fileID: 8160204976897718487}
+  m_Layer: 5
+  m_Name: Boss
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1912900429506284773
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5212749226945669879}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2048201407022927467}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20, y: 19}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &5544051856517773553
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5212749226945669879}
+  m_CullTransparentMesh: 1
+--- !u!114 &8160204976897718487
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5212749226945669879}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: boss
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 73b01ffd92afd9a49aa2dcd7855bb7cd, type: 2}
+  m_sharedMaterial: {fileID: 653763243914918457, guid: 73b01ffd92afd9a49aa2dcd7855bb7cd, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5302598583893176286
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3904323940263915134}
+  - component: {fileID: 8537283746161711259}
+  - component: {fileID: 7876687511766144582}
+  m_Layer: 5
+  m_Name: BarBG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3904323940263915134
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5302598583893176286}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 9, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2048201407022927467}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 15, y: 0}
+  m_SizeDelta: {x: 115, y: 24}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &8537283746161711259
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5302598583893176286}
+  m_CullTransparentMesh: 1
+--- !u!114 &7876687511766144582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5302598583893176286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: eadcebcc04cf0b04ab81525a6425ce09, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5859008537932839694
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3071892659551274024}
+  - component: {fileID: 199265238298561072}
+  - component: {fileID: 1632848933924881357}
+  m_Layer: 5
+  m_Name: FillHP
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3071892659551274024
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5859008537932839694}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6698612592391412951}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 3, y: 0}
+  m_SizeDelta: {x: 120, y: 24}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &199265238298561072
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5859008537932839694}
+  m_CullTransparentMesh: 1
+--- !u!114 &1632848933924881357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5859008537932839694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 99087cf4276959b489f676f445cf876e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5876450858699928475
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6024049827191089538}
+  - component: {fileID: 1264163728326363767}
+  - component: {fileID: 1305832796103675322}
+  m_Layer: 5
+  m_Name: Follwup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6024049827191089538
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5876450858699928475}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2048201407022927467}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -35, y: 0}
+  m_SizeDelta: {x: 0, y: 4}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &1264163728326363767
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5876450858699928475}
+  m_CullTransparentMesh: 1
+--- !u!114 &1305832796103675322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5876450858699928475}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 393859c2f05dd8048a3a15c2daede97b, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 0
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6619441702066681193
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4736431474040562949}
+  - component: {fileID: 401749126159256917}
+  - component: {fileID: 4166559455476866893}
+  m_Layer: 5
+  m_Name: BarCover
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4736431474040562949
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6619441702066681193}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 9, y: 6, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2048201407022927467}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 120, y: 8}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &401749126159256917
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6619441702066681193}
+  m_CullTransparentMesh: 1
+--- !u!114 &4166559455476866893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6619441702066681193}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5bb74bcd3218af041a8d483d5fdccfec, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/JDW/Assets/Scenes/Ui/BossHPbarZone (1).prefab.meta
+++ b/Assets/JDW/Assets/Scenes/Ui/BossHPbarZone (1).prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 15690d0990626e44f851b5ce85711fe2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JDW/Assets/Scenes/Ui/HPbarZone (1).prefab
+++ b/Assets/JDW/Assets/Scenes/Ui/HPbarZone (1).prefab
@@ -32,7 +32,6 @@ RectTransform:
   - {fileID: 4747971911304988324}
   - {fileID: 3596316069652633233}
   - {fileID: 7131655237221510150}
-  - {fileID: 1260317920430230525}
   - {fileID: 2244006241173786178}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -151,140 +150,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 1
---- !u!1 &7166371230185166899
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1260317920430230525}
-  - component: {fileID: 6701120945005115346}
-  - component: {fileID: 3321122807256419268}
-  m_Layer: 5
-  m_Name: Boss
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1260317920430230525
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7166371230185166899}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3849775940481999286}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 20, y: 19}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0, y: 1}
---- !u!222 &6701120945005115346
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7166371230185166899}
-  m_CullTransparentMesh: 1
---- !u!114 &3321122807256419268
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7166371230185166899}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: boss
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 73b01ffd92afd9a49aa2dcd7855bb7cd, type: 2}
-  m_sharedMaterial: {fileID: 653763243914918457, guid: 73b01ffd92afd9a49aa2dcd7855bb7cd, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 40
-  m_fontSizeBase: 40
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 1
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7299295138209099044
 GameObject:
   m_ObjectHideFlags: 0
@@ -351,81 +216,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 5bb74bcd3218af041a8d483d5fdccfec, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!1 &7574037192109061622
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4747971911304988324}
-  - component: {fileID: 2476479516504000263}
-  - component: {fileID: 3620415110420386905}
-  m_Layer: 5
-  m_Name: BarBG
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &4747971911304988324
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7574037192109061622}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 9, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3849775940481999286}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 15, y: 0}
-  m_SizeDelta: {x: 115, y: 24}
-  m_Pivot: {x: 0, y: 0.5}
---- !u!222 &2476479516504000263
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7574037192109061622}
-  m_CullTransparentMesh: 1
---- !u!114 &3620415110420386905
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7574037192109061622}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: eadcebcc04cf0b04ab81525a6425ce09, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -585,3 +375,105 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1001 &460567502827761979
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3849775940481999286}
+    m_Modifications:
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 115
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8032206246652331213, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+      propertyPath: m_Name
+      value: BarBG
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+--- !u!224 &4747971911304988324 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5152237786287241119, guid: 29cb71f9f4f113449910f16377ddc252, type: 3}
+  m_PrefabInstance: {fileID: 460567502827761979}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/JDW/Assets/Scenes/Ui/Script/UiManager.cs
+++ b/Assets/JDW/Assets/Scenes/Ui/Script/UiManager.cs
@@ -1,5 +1,6 @@
 ﻿using ProjectVS;
 using ProjectVS.Data;
+using ProjectVS.Manager;
 
 using TMPro;
 
@@ -12,7 +13,7 @@ public class UiManager : MonoBehaviour
     public PixelUI.ValueBar BossHpBar;//보스 체력바를 채울 이미지
     public PlayerConfig player;
     public Boss boss;
-    public PlayerData playerData;
+    public PlayerDataManager playerDataManager;
 
     public TextMeshProUGUI levelText; // 레벨 
     public TextMeshProUGUI goldText;//골드
@@ -56,6 +57,6 @@ public class UiManager : MonoBehaviour
         }
         // 플레이어 레벨, 골드 텍스트
         levelText.text = $"{Mathf.FloorToInt(player.Stats.Level)}";
-        goldText.text = $"{Mathf.FloorToInt(playerData.Gold)}";
+        goldText.text = $"{Mathf.FloorToInt(playerDataManager.gold)}";
     }
 }

--- a/Assets/JDW/Assets/Scenes/Ui/Script/UiManager.cs
+++ b/Assets/JDW/Assets/Scenes/Ui/Script/UiManager.cs
@@ -4,59 +4,95 @@ using ProjectVS.Manager;
 
 using TMPro;
 
+using Unity.VisualScripting.Antlr3.Runtime.Misc;
+
 using UnityEngine;
 using UnityEngine.UI;
-// 추후 Ui관련 팀원분과 조율해서 합칠예정
-public class UiManager : MonoBehaviour
+namespace ProjectVS.Utils.UIManager
 {
-    public PixelUI.ValueBar ExpBar;//경험치바를 채울 이미지
-    public PixelUI.ValueBar BossHpBar;//보스 체력바를 채울 이미지
-    public PlayerConfig player;
-    public Boss boss;
-    public PlayerDataManager playerDataManager;
-
-    public TextMeshProUGUI levelText; // 레벨 
-    public TextMeshProUGUI goldText;//골드
-    private void Awake()
+    // 추후 Ui관련 팀원분과 조율 예정
+    public class UiManager : MonoBehaviour
     {
-        player = FindObjectOfType<PlayerConfig>();
-        boss = FindObjectOfType<Boss>();
-    }
-    private void Start()
-    {
-        //초기에 플레이어가 없을 경우 대체값
-        if (ExpBar != null)
-        {
-            ExpBar.CurrentValue = 0f;
-            ExpBar.MaxValue = 1f; // 비율 기반이라서 0~1
-        }
-    }
+        public PixelUI.ValueBar ExpBar;//경험치바를 채울 이미지
+        public PixelUI.ValueBar BossHpBar;//보스 체력바를 채울 이미지
+        public PlayerConfig Player;
+        public Boss Boss;
+        public PlayerDataManager PlayerDataManager;
 
-    private void Update()
-    {
-        if (player == null)
-            player = FindObjectOfType<PlayerConfig>(); // 자동으로 플레이어 찾음       
-        if (boss == null)
-            boss = FindObjectOfType<Boss>(); // 자동으로 보스를 찾음       
+        public TextMeshProUGUI LevelText; // 레벨 
+        public TextMeshProUGUI GoldText;//골드
 
-        // 플레이어나 스탯이 없으면 실행x
-        if (player == null || player.Stats == null) return;
-        // 경험치 비율 
-        float expRatio = player.Stats.CurrentExp / player.Stats.MaxExp;
-        if (ExpBar != null)
+        [SerializeField] private Sprite[] _hpPortraits;
+        [SerializeField] private Image _portraitImage;
+        private void Awake()
         {
-            ExpBar.MaxValue = player.Stats.MaxExp;
-            ExpBar.CurrentValue = player.Stats.CurrentExp;
+            Player = FindObjectOfType<PlayerConfig>();
+            Boss = FindObjectOfType<Boss>();
         }
-        // 보스 체력 비율
-        if (boss != null && BossHpBar != null)
+        private void Start()
         {
-            float bossHpRatio = boss.currentHp / boss.maxHp;
-            BossHpBar.MaxValue = boss.maxHp;
-            BossHpBar.CurrentValue = boss.currentHp;
+            //초기에 플레이어가 없을 경우 대체값
+            if (ExpBar != null)
+            {
+                ExpBar.CurrentValue = 0f;
+                ExpBar.MaxValue = 1f; // 비율 기반이라서 0~1
+            }
         }
-        // 플레이어 레벨, 골드 텍스트
-        levelText.text = $"{Mathf.FloorToInt(player.Stats.Level)}";
-        goldText.text = $"{Mathf.FloorToInt(playerDataManager.gold)}";
+
+        private void Update()
+        {
+            if (Player == null)
+                Player = FindObjectOfType<PlayerConfig>(); // 자동으로 플레이어 찾음       
+            if (Boss == null)
+                Boss = FindObjectOfType<Boss>(); // 자동으로 보스를 찾음
+
+
+            UpdateExpBar();
+            UpdateBossHpBar();
+            UpdateTexts();
+        }
+        public void UpdatePortrait(float hpRatio)
+        {
+
+            hpRatio = Mathf.Clamp01(hpRatio);
+
+            if (hpRatio > 0.8f)
+                _portraitImage.sprite = _hpPortraits[4];
+            else if (hpRatio > 0.6f)
+                _portraitImage.sprite = _hpPortraits[3];
+            else if (hpRatio > 0.4f)
+                _portraitImage.sprite = _hpPortraits[2];
+            else if (hpRatio > 0.2f)
+                _portraitImage.sprite = _hpPortraits[1];
+            else
+                _portraitImage.sprite = _hpPortraits[0];
+        }
+
+        private void UpdateExpBar()
+        {
+            if (ExpBar == null || Player == null || Player.Stats == null)
+                return;
+
+            ExpBar.MaxValue = Player.Stats.MaxExp;
+            ExpBar.CurrentValue = Player.Stats.CurrentExp;
+        }
+
+        private void UpdateBossHpBar()
+        {
+            if (Boss == null || BossHpBar == null)
+                return;
+
+            BossHpBar.MaxValue = Boss.maxHp;
+            BossHpBar.CurrentValue = Boss.currentHp;
+        }
+
+        private void UpdateTexts()
+        {
+            if (LevelText != null)
+                LevelText.text = $"{Mathf.FloorToInt(Player.Stats.Level)}";
+
+            if (GoldText != null && PlayerDataManager != null)
+                GoldText.text = $"{Mathf.FloorToInt(PlayerDataManager.gold)}";
+        }
     }
 }

--- a/Assets/SJO/Scripts/Weapon.cs
+++ b/Assets/SJO/Scripts/Weapon.cs
@@ -118,9 +118,9 @@ public class Weapon : MonoBehaviour
 
     private void Fire()
     {
-        if (!player.scanner.nearestTarget) return;
+        if (!player.Scanner.nearestTarget) return;
 
-        Vector3 targetPos = player.scanner.nearestTarget.position;
+        Vector3 targetPos = player.Scanner.nearestTarget.position;
         Vector3 dir = (targetPos - transform.position).normalized;
 
         GameObject obj = _poolManager.Spawn(poolKey, transform.position, Quaternion.identity);

--- a/Assets/Scripts/Manager/StageManager.cs
+++ b/Assets/Scripts/Manager/StageManager.cs
@@ -26,7 +26,7 @@ namespace ProjectVS.Manager
         [field: SerializeField] public StageResult StageResult { get; private set; } = StageResult.None;
 
         [Header("UI")]                                              
-        [SerializeField] private TimerView _timerView;  // timer  HUD
+        [SerializeField] private TimerView _timerView;  // Timer  HUD
         [SerializeField] private TimerView _pausedView; // paused pupup
         // [SerializeField] private TimerView _resultView; // result pupup
 

--- a/Assets/TextMesh Pro/Examples & Extras/Scripts/CameraController.cs
+++ b/Assets/TextMesh Pro/Examples & Extras/Scripts/CameraController.cs
@@ -70,7 +70,7 @@ namespace TMPro.Examples
         {
             if (CameraTarget == null)
             {
-                // If we don't have a target (assigned by the player, create a dummy in the center of the scene).
+                // If we don't have a target (assigned by the _player, create a dummy in the center of the scene).
                 dummyTarget = new GameObject("Camera Target").transform;
                 CameraTarget = dummyTarget;
             }

--- a/Assets/TextMesh Pro/Examples & Extras/Scripts/TMP_FrameRateCounter.cs
+++ b/Assets/TextMesh Pro/Examples & Extras/Scripts/TMP_FrameRateCounter.cs
@@ -16,7 +16,7 @@ namespace TMPro.Examples
         public FpsCounterAnchorPositions AnchorPosition = FpsCounterAnchorPositions.TopRight;
 
         private string htmlColorTag;
-        private const string fpsLabel = "{0:2}</color> <#8080ff>FPS \n<#FF8000>{1:2} <#8080ff>MS";
+        private const string fpsLabel = "{0:2}</color> <#8080ff>FPS \n<#FF8000>{1:2} <#8080ff>MapSwitcher";
 
         private TextMeshPro m_TextMeshPro;
         private Transform m_frameCounter_transform;
@@ -90,7 +90,7 @@ namespace TMPro.Examples
                 else
                     htmlColorTag = "<color=green>";
 
-                //string format = System.String.Format(htmlColorTag + "{0:F2} </color>FPS \n{1:F2} <#8080ff>MS",fps, ms);
+                //string format = System.String.Format(htmlColorTag + "{0:F2} </color>FPS \n{1:F2} <#8080ff>MapSwitcher",fps, ms);
                 //m_TextMeshPro.text = format;
 
                 m_TextMeshPro.SetText(htmlColorTag + fpsLabel, fps, ms);

--- a/Assets/TextMesh Pro/Examples & Extras/Scripts/TMP_UiFrameRateCounter.cs
+++ b/Assets/TextMesh Pro/Examples & Extras/Scripts/TMP_UiFrameRateCounter.cs
@@ -16,7 +16,7 @@ namespace TMPro.Examples
         public FpsCounterAnchorPositions AnchorPosition = FpsCounterAnchorPositions.TopRight;
 
         private string htmlColorTag;
-        private const string fpsLabel = "{0:2}</color> <#8080ff>FPS \n<#FF8000>{1:2} <#8080ff>MS";
+        private const string fpsLabel = "{0:2}</color> <#8080ff>FPS \n<#FF8000>{1:2} <#8080ff>MapSwitcher";
 
         private TextMeshProUGUI m_TextMeshPro;
         private RectTransform m_frameCounter_transform;


### PR DESCRIPTION
### 주요 기능
- 플레이어 체력 비율에 따라 초상화 Sprite 자동 변경 기능 추가
  - UIManager(UpdatePortrait)에서 체력 비율 기반으로 Sprite 교체
  - PlayerConfig에서 체력 변화 시 자동 호출되도록 연동

- Axe 클래스에서 HP 바가 출력되지 않던 문제 수정
  - 프리팹 내 Canvas 위치/스케일 조정
  - HPBarZone의 RectTransform 재설정 및 Canvas RenderMode = WorldSpace 적용

---

### 리팩토링
- PlayerSpawner에서 PlayerConfig 및 AttackPosition 설정 분리

---

### 기타 수정 사항
- TSV 파일에서 캐릭터 능력치 불러와서 생성된 Player에 적용
- AttackPosition 관련 회전 문제 수정
- 병합 후 클래스/스탯 초기화 로직 정리 및 외존성 문제 임시 비활성화

---

### 테스트
- HP 변화에 따른 초상화 정상 교체 확인
- Axe 클래스로 플레이 시 체력바 정상 표시 확인